### PR TITLE
INode.HasChildNodes is now exposed as a method to DOM

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -1,0 +1,30 @@
+namespace AngleSharp.Js.Tests
+{
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class DomTests
+    {
+        [Test]
+        public async Task NodeHasChildNodesIsAFunction()
+        {
+            var result = await "document.createElement('div').hasChildNodes".EvalScriptAsync();
+            Assert.AreEqual("function hasChildNodes() { [native code] }", result);
+        }
+
+        [Test]
+        public async Task NodeHasChildNodesWithoutChildren()
+        {
+            var result = await "document.createElement('div').hasChildNodes()".EvalScriptAsync();
+            Assert.AreEqual("False", result);
+        }
+
+        [Test]
+        public async Task NodeHasChildNodesWithChildren()
+        {
+            var result = await "new DOMParser().parseFromString(`<div><input/></div>`, 'text/html').body.firstChild.hasChildNodes()".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+    }
+}

--- a/src/AngleSharp.Js/Extensions/Extensibility.cs
+++ b/src/AngleSharp.Js/Extensions/Extensibility.cs
@@ -49,6 +49,9 @@ namespace AngleSharp.Js
                             case Accessors.Adder:
                                 entry.Adder = method;
                                 break;
+                            case Accessors.Method:
+                                entry.Other = method;
+                                break;
                         }
                     }
                     else

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -148,14 +148,32 @@ namespace AngleSharp.Js
             foreach (var property in properties)
             {
                 var indexParameters = property.GetIndexParameters();
-                var index = property.GetCustomAttribute<DomAccessorAttribute>();
+                var accessor = property.GetCustomAttribute<DomAccessorAttribute>()?.Type;
                 var putsForward = property.GetCustomAttribute<DomPutForwardsAttribute>();
                 var names = property
                     .GetCustomAttributes<DomNameAttribute>()
                     .Select(m => m.OfficialName)
                     .ToArray();
 
-                if (index != null || Array.Exists(names, m => m.Is("item")))
+                if (accessor == Accessors.Method)
+                {
+                    // property decorated with Method accessor, so we need to treat it as a method, not a property
+
+                    if (property.GetMethod == null)
+                    {
+                        throw new InvalidOperationException("Getter not found.");
+                    }
+
+                    foreach (var name in names)
+                    {
+                        SetMethod(name, property.GetMethod);
+                    }
+
+                    // methods were set, so finish processing
+                    return;
+                }
+
+                if (accessor == Accessors.Getter || accessor == Accessors.Setter || Array.Exists(names, m => m.Is("item")))
                 {
                     SetIndexer(property, indexParameters);
                 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes AngleSharp/AngleSharp#1219

Handling of new `Accessors.Method` member added, which was required to correctly expose the property.

Current pull request is only a part of the fix. First part: AngleSharp/AngleSharp#1224

> [!WARNING]
> Code in this fix won't compile until the current project references AngleSharp version with `Accessors.Method` implemented.