### PR TITLE
Fix indexed access into DOM collections

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -26,5 +26,33 @@ namespace AngleSharp.Js.Tests
             var result = await "new DOMParser().parseFromString(`<div><input/></div>`, 'text/html').body.firstChild.hasChildNodes()".EvalScriptAsync();
             Assert.AreEqual("True", result);
         }
+
+        [Test]
+        public async Task NumericIndexerOfHtmlCollectionYieldsTheElement()
+        {
+            var result = await "document.getElementsByTagName('script')[0].nodeName".EvalScriptAsync();
+            Assert.AreEqual("SCRIPT", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfHtmlCollectionOutOfRangeIsUndefined()
+        {
+            var result = await "typeof document.getElementsByTagName('script')[5]".EvalScriptAsync();
+            Assert.AreEqual("undefined", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfNodeListYieldsTheNode()
+        {
+            var result = await "new DOMParser().parseFromString(`<div><input/></div>`, 'text/html').body.childNodes[0].nodeName".EvalScriptAsync();
+            Assert.AreEqual("DIV", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfTokenListYieldsTheToken()
+        {
+            var result = await "new DOMParser().parseFromString(`<div class='a b'></div>`, 'text/html').body.firstChild.classList[1]".EvalScriptAsync();
+            Assert.AreEqual("b", result);
+        }
     }
 }

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -15,9 +15,10 @@ namespace AngleSharp.Js
     {
         private readonly String _name;
         private readonly EngineInstance _instance;
+        private readonly Type _type;
 
-        private PropertyInfo _numericIndexer;
-        private PropertyInfo _stringIndexer;
+        private MethodInfo _numericIndexer;
+        private MethodInfo _stringIndexer;
 
         public DomPrototypeInstance(EngineInstance engine, Type type)
             : base(engine.Jint)
@@ -25,6 +26,7 @@ namespace AngleSharp.Js
             var baseType = type.GetTypeInfo().BaseType ?? typeof(Object);
             _name = type.GetOfficialName(baseType);
             _instance = engine;
+            _type = type;
 
             Set(GlobalSymbolRegistry.ToStringTag, _name);
 
@@ -45,7 +47,7 @@ namespace AngleSharp.Js
                 try
                 {
                     var args = new Object[] { numericIndex };
-                    var orig = _numericIndexer.GetMethod.Invoke(value, args);
+                    var orig = _numericIndexer.Invoke(value, args);
                     result = new PropertyDescriptor(orig.ToJsValue(_instance), false, false, false);
                     return true;
                 }
@@ -70,7 +72,7 @@ namespace AngleSharp.Js
             if (_stringIndexer != null && !HasProperty(index))
             {
                 var args = new Object[] { index };
-                var valueAtIndex = _stringIndexer.GetMethod.Invoke(value, args);
+                var valueAtIndex = _stringIndexer.Invoke(value, args);
 
                 if (valueAtIndex == null)
                 {
@@ -229,17 +231,52 @@ namespace AngleSharp.Js
 
         private void SetIndexer(PropertyInfo property, ParameterInfo[] indexParameters)
         {
-            if (indexParameters.Length == 1)
+            if (indexParameters.Length != 1)
             {
-                if (indexParameters[0].ParameterType == typeof(Int32))
-                {
-                    _numericIndexer = property;
-                }
-                else if (indexParameters[0].ParameterType == typeof(String))
-                {
-                    _stringIndexer = property;
-                }
+                return;
             }
+
+            var getter = ResolveAccessor(property.GetMethod);
+
+            if (getter == null)
+            {
+                return;
+            }
+
+            if (indexParameters[0].ParameterType == typeof(Int32))
+            {
+                _numericIndexer = getter;
+            }
+            else if (indexParameters[0].ParameterType == typeof(String))
+            {
+                _stringIndexer = getter;
+            }
+        }
+
+        private MethodInfo ResolveAccessor(MethodInfo accessor)
+        {
+            //  An interface may re-implement a member of one of its own base interfaces
+            //  explicitly, e.g. "T IReadOnlyList<T>.this[Int32 index]" declared on an
+            //  IHtmlCollection<T>. Such a member is private and abstract - invoking it
+            //  reflectively throws an EntryPointNotFoundException because the actual
+            //  implementation lives in a different slot. Resolve it against the type the
+            //  prototype was created for, which is where the implementation can be found.
+            if (accessor == null || accessor.IsPublic)
+            {
+                return accessor;
+            }
+
+            var name = accessor.Name;
+            var simpleName = name.Substring(name.LastIndexOf('.') + 1);
+            var parameters = accessor.GetParameters();
+            var parameterTypes = new Type[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parameterTypes[i] = parameters[i].ParameterType;
+            }
+
+            return _type.GetRuntimeMethod(simpleName, parameterTypes) ?? accessor;
         }
 
         private void SetMethod(String name, MethodInfo method)


### PR DESCRIPTION
Indexing a DOM collection from script throws:

```js
document.getElementsByTagName('p')[0]   // TargetInvocationException
element.classList[0]                    // TargetInvocationException
```

with an inner `System.EntryPointNotFoundException`. jQuery is built on this, so most of it does not work.

### Cause

`IHtmlCollection<T>`, `ITokenList` and `IStringList` declare their numeric indexer as an explicit re-implementation of `IReadOnlyList<T>`'s indexer:

```
IHtmlCollection`1.System.Collections.Generic.IReadOnlyList<T>.Item(Int32)
  accessor = Getter, DomName = "item", getter is private + abstract
```

A member declared that way on an interface cannot be invoked through the `MethodInfo` the interface hands out: the slot is abstract and the implementation lives elsewhere, so the runtime has no entry point for the method we pass it. `DomPrototypeInstance.TryGetFromIndex` calls exactly that `MethodInfo`.

### Change

Resolve the indexer accessor once, when the prototype is built, against the type the prototype belongs to, and store the resolved `MethodInfo`. Public accessors - the common case, including every string indexer and the numeric indexers of `INodeList`, `INamedNodeMap`, `IStyleSheetList` and friends - are used unchanged.

### Tests

Six tests are currently failing on `devel` on .NET (Core); they pass with this change:

* `ScriptingTests.GetQuerySelectorScriptEqualsGetTagNameScript`
* `ScriptingTests.GetQuerySelectorScriptNotEqualsGetTagNameBody`
* `JqueryTests.JqueryVersionOne`
* `JqueryTests.JqueryVersionOneTwelveFour_Issue43`
* `JqueryTests.JqueryWithSettingHtmlProperty`
* `JqueryTests.JqueryWithSettingTextProperty`

Note the suite is green on `net462`/`net472` either way - default interface members do not exist there, so the affected members have a different shape - which is presumably why this went unnoticed.

Four tests were added to `DomTests` covering the numeric indexer of a collection, of a node list, of a token list, and an out-of-range index.

`net462`, `net472` and `net8.0`: 122 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik