### PR TITLE
Stop DOM nodes from claiming inherited members as own properties

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -82,5 +82,33 @@ namespace AngleSharp.Js.Tests
             var result = await "(function () { window.console.marker = 'kept'; return window.console.marker; })()".EvalScriptAsync();
             Assert.AreEqual("kept", result);
         }
+
+        [Test]
+        public async Task InheritedMemberIsNotAnOwnPropertyOfTheNode()
+        {
+            var result = await "document.createElement('div').hasOwnProperty('firstChild')".EvalScriptAsync();
+            Assert.AreEqual("False", result);
+        }
+
+        [Test]
+        public async Task InheritedMemberIsStillVisibleOnTheNode()
+        {
+            var result = await "('firstChild' in document.documentElement) + ',' + (typeof document.documentElement.appendChild)".EvalScriptAsync();
+            Assert.AreEqual("true,function", result);
+        }
+
+        [Test]
+        public async Task InheritedAccessorStillReadsAndWrites()
+        {
+            var result = await "(function () { var d = document.createElement('div'); d.id = 'jint'; return d.id; })()".EvalScriptAsync();
+            Assert.AreEqual("jint", result);
+        }
+
+        [Test]
+        public async Task AssignedPropertyIsReportedConsistently()
+        {
+            var result = await "(function () { var d = document.createElement('div'); d.custom = 1; return d.hasOwnProperty('custom') + ',' + Object.getOwnPropertyNames(d).join(); })()".EvalScriptAsync();
+            Assert.AreEqual("true,custom", result);
+        }
     }
 }

--- a/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
@@ -67,18 +67,14 @@ namespace AngleSharp.Js
 
         public override PropertyDescriptor GetOwnProperty(JsValue property)
         {
-            if (Prototype is DomPrototypeInstance prototype)
+            //  An indexer is the only thing that can turn into an own property of the node
+            //  itself. The members of the DOM interface live on the prototype, so finding
+            //  them is the engine's job - answering them here would make the node claim
+            //  every inherited member as its own.
+            if (Prototype is DomPrototypeInstance prototype &&
+                prototype.TryGetFromIndex(_value, property.ToString(), out var descriptor))
             {
-                if (prototype.TryGetFromIndex(_value, property.ToString(), out var descriptor))
-                {
-                    return descriptor;
-                }
-
-                var prototypeProperty = prototype.GetOwnProperty(property);
-                if (prototypeProperty != PropertyDescriptor.Undefined)
-                {
-                    return prototypeProperty;
-                }
+                return descriptor;
             }
 
             return base.GetOwnProperty(property);


### PR DESCRIPTION
`DomNodeInstance.GetOwnProperty` falls back to returning the prototype's descriptor when the node has no own property of that name. `[[GetOwnProperty]]` is not supposed to look past the object itself, so a node ends up disagreeing with itself:

```js
document.body.hasOwnProperty('firstChild')                       // true
Object.getOwnPropertyDescriptor(document.body, 'firstChild')     // an accessor
Object.getOwnPropertyNames(document.body)                        // []
Object.keys(document.body)                                       // []
```

Library code that feature-detects with `hasOwnProperty` before walking the prototype chain gets the wrong answer, and anything that pairs `getOwnPropertyNames` with `getOwnPropertyDescriptor` sees an object whose keys and descriptors do not agree.

### Change

Drop the fallback. An indexer is the only thing that can legitimately produce an own property here, so that probe stays; everything else is a member of the DOM interface, lives on the prototype, and is found by the engine's ordinary own -> prototype lookup.

Reads, writes, method calls and `in` are unaffected - only the "is this mine?" answer changes.

### Effect on member lookup

This started as a correctness fix, and on the Jint version the branch was written against that is all it was. Now that #120 has moved the project to Jint 4.14.0, the change has a second, mechanical consequence worth recording. Both points below are read off the engine's code path; nothing here has been measured.

`JintMemberExpression` resolves `node.member` by first asking the receiver whether it has an own property of that name.

- **A redundant probe disappears.** With the fallback in place the override runs twice per read: once for that own-property question, and again inside the slow path of `ObjectInstance.Get`. Each run walks to the prototype and asks it for the descriptor. Without the fallback the first question misses cheaply and the engine resolves the member on the prototype itself, so the second walk is gone.
- **A per-site prototype cache becomes reachable.** Jint 4.14.0 caches the resolved descriptor per member-access site, but installs the entry *only* when the receiver reports no own property for the name - precisely what the fallback prevented. Worth being clear about the shape of this: the entry is keyed on the receiver instance, so it pays off on repeated reads of the same node at the same site, not on a traversal that touches a different node each iteration. It also only covers members found on the direct prototype, which is the case here because each DOM prototype registers the whole interface tree.

Neither point is the reason for the change; the own-property answer being wrong is. They are noted because the version bump quietly turned a neutral change into a mildly beneficial one.

### Tests

`DomTests.InheritedMemberIsNotAnOwnPropertyOfTheNode` fails on `devel` and passes here. Three further tests pin the behaviour that must not change: the member is still visible through the prototype, an inherited accessor still reads and writes, and a property assigned from script is still reported by both `hasOwnProperty` and `getOwnPropertyNames`.

I also diffed the full own-property name set and `Symbol.toStringTag` of every prototype in the chain of ten different DOM object kinds, plus the global object, before and after: byte-identical. That comparison was re-run against the current `devel`, since #117 changed when prototype members get registered.

Rebased onto current `devel`. The suite is green on `net8.0`, `net462` and `net472` - 131 tests on `devel`, 135 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
