### PR TITLE
Keep event handler properties per node instead of per prototype

### DIFF
--- a/src/AngleSharp.Js.Tests/FireEventTests.cs
+++ b/src/AngleSharp.Js.Tests/FireEventTests.cs
@@ -157,6 +157,76 @@ document.onclick();
         }
 
         [Test]
+        public async Task ClickHandlerIsKeptPerElement()
+        {
+            var service = new JsScriptingService();
+            var cfg = Configuration.Default.With(service).WithEventLoop();
+            var html = @"<!doctype html>
+<html>
+<body>
+<div id=a></div>
+<div id=b></div>
+<script>
+var log = [];
+var a = document.getElementById('a');
+var b = document.getElementById('b');
+var f = function () { log.push('f'); };
+var g = function () { log.push('g'); };
+a.onclick = f;
+b.onclick = g;
+var aIsF = a.onclick === f;
+var bIsG = b.onclick === g;
+var shared = a.onclick === b.onclick;
+a.dispatchEvent(new MouseEvent('click'));
+b.dispatchEvent(new MouseEvent('click'));
+</script>
+</body>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+            var engine = service.GetOrCreateJint(document);
+
+            Assert.IsTrue(engine.GetValue("aIsF").AsBoolean());
+            Assert.IsTrue(engine.GetValue("bIsG").AsBoolean());
+            Assert.IsFalse(engine.GetValue("shared").AsBoolean());
+
+            var log = engine.GetValue("log").AsArray();
+            Assert.AreEqual(2.0, log.Get("length").AsNumber());
+            Assert.AreEqual("f", log.Get("0").AsString());
+            Assert.AreEqual("g", log.Get("1").AsString());
+        }
+
+        [Test]
+        public async Task ClearingClickHandlerOfOneElementKeepsTheOther()
+        {
+            var service = new JsScriptingService();
+            var cfg = Configuration.Default.With(service).WithEventLoop();
+            var html = @"<!doctype html>
+<html>
+<body>
+<div id=a></div>
+<div id=b></div>
+<script>
+var log = [];
+var a = document.getElementById('a');
+var b = document.getElementById('b');
+a.onclick = function () { log.push('f'); };
+b.onclick = function () { log.push('g'); };
+a.onclick = null;
+var cleared = a.onclick === null;
+a.dispatchEvent(new MouseEvent('click'));
+b.dispatchEvent(new MouseEvent('click'));
+</script>
+</body>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+            var engine = service.GetOrCreateJint(document);
+
+            Assert.IsTrue(engine.GetValue("cleared").AsBoolean());
+
+            var log = engine.GetValue("log").AsArray();
+            Assert.AreEqual(1.0, log.Get("length").AsNumber());
+            Assert.AreEqual("g", log.Get("0").AsString());
+        }
+
+        [Test]
         public async Task BodyOnloadWorksWhenSetAsAttributeInitially()
         {
             var cfg = Configuration.Default.WithJs().WithEventLoop();

--- a/src/AngleSharp.Js/Proxies/DomEventInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomEventInstance.cs
@@ -13,8 +13,6 @@ namespace AngleSharp.Js
         private readonly EngineInstance _engine;
         private readonly MethodInfo _addHandler;
         private readonly MethodInfo _removeHandler;
-        private DomEventHandler _handler;
-        private Function _function;
 
         public DomEventInstance(EngineInstance engine, MethodInfo addHandler, MethodInfo removeHandler)
         {
@@ -29,8 +27,12 @@ namespace AngleSharp.Js
 
         public ClrFunction Setter { get; }
 
-        private JsValue GetEventHandler(JsValue thisObject, JsValue[] arguments) =>
-            _function ?? JsValue.Null;
+        private JsValue GetEventHandler(JsValue thisObject, JsValue[] arguments)
+        {
+            var node = thisObject.As<DomNodeInstance>();
+            var registration = node?.GetEventHandler(this);
+            return registration?.Function ?? JsValue.Null;
+        }
 
         private JsValue SetEventHandler(JsValue thisObject, JsValue[] arguments)
         {
@@ -38,28 +40,50 @@ namespace AngleSharp.Js
 
             if (node != null)
             {
-                if (_handler != null)
+                var previous = node.RemoveEventHandler(this);
+
+                if (previous != null)
                 {
-                    _removeHandler?.Invoke(node.Value, new Object[] { _handler });
-                    _handler = null;
-                    _function = null;
+                    _removeHandler?.Invoke(node.Value, new Object[] { previous.Handler });
                 }
 
-                if (arguments[0] is Function)
+                if (arguments[0] is Function function)
                 {
-                    _function = arguments[0].As<Function>();
-                    _handler = (s, ev) =>
+                    DomEventHandler handler = (s, ev) =>
                     {
                         var sender = s.ToJsValue(_engine);
                         var args = ev.ToJsValue(_engine);
-                        _function.Call(sender, new[] { args });
+                        function.Call(sender, new[] { args });
                     };
 
-                    _addHandler?.Invoke(node.Value, new Object[] { _handler });
+                    node.SetEventHandler(this, new Registration(function, handler));
+                    _addHandler?.Invoke(node.Value, new Object[] { handler });
                 }
             }
 
             return arguments[0];
+        }
+
+        /// <summary>
+        /// The handler currently assigned to a single node for a single event.
+        /// </summary>
+        public sealed class Registration
+        {
+            public Registration(Function function, DomEventHandler handler)
+            {
+                Function = function;
+                Handler = handler;
+            }
+
+            /// <summary>
+            /// The function that was assigned, as it has to be handed back on read.
+            /// </summary>
+            public Function Function { get; }
+
+            /// <summary>
+            /// The listener that was subscribed, as it has to be handed back on removal.
+            /// </summary>
+            public DomEventHandler Handler { get; }
         }
     }
 }

--- a/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
@@ -5,11 +5,14 @@ namespace AngleSharp.Js
     using Jint.Native.Object;
     using Jint.Runtime.Descriptors;
     using System;
+    using System.Collections.Generic;
 
     sealed class DomNodeInstance : ObjectInstance
     {
         private readonly EngineInstance _instance;
         private readonly Object _value;
+
+        private Dictionary<DomEventInstance, DomEventInstance.Registration> _eventHandlers;
 
         public DomNodeInstance(EngineInstance engine, Object value)
             : base(engine.Jint)
@@ -23,6 +26,44 @@ namespace AngleSharp.Js
         public Object Value => _value;
 
         public override object ToObject() => _value;
+
+        /// <summary>
+        /// Gets the handler assigned to this node for the given event, if any.
+        /// The handler is per node - the <see cref="DomEventInstance"/> itself is
+        /// shared by every node using the same prototype.
+        /// </summary>
+        public DomEventInstance.Registration GetEventHandler(DomEventInstance ev)
+        {
+            if (_eventHandlers != null && _eventHandlers.TryGetValue(ev, out var registration))
+            {
+                return registration;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Assigns the handler for the given event to this node.
+        /// </summary>
+        public void SetEventHandler(DomEventInstance ev, DomEventInstance.Registration registration)
+        {
+            _eventHandlers = _eventHandlers ?? new Dictionary<DomEventInstance, DomEventInstance.Registration>();
+            _eventHandlers[ev] = registration;
+        }
+
+        /// <summary>
+        /// Removes and returns the handler assigned to this node for the given event, if any.
+        /// </summary>
+        public DomEventInstance.Registration RemoveEventHandler(DomEventInstance ev)
+        {
+            if (_eventHandlers != null && _eventHandlers.TryGetValue(ev, out var registration))
+            {
+                _eventHandlers.Remove(ev);
+                return registration;
+            }
+
+            return null;
+        }
 
         public override PropertyDescriptor GetOwnProperty(JsValue property)
         {


### PR DESCRIPTION
`onclick` and friends are exposed through a `DomEventInstance` that is created once per prototype - and it stores the assigned function and the subscribed listener in its own fields. Every node of that type therefore shares one handler slot:

```js
a.onclick = f;
b.onclick = g;
a.onclick === g           // true
a.onclick === b.onclick   // true
```

Assigning to `b` also unsubscribes `f` from `a`, so `a` stops reacting to its own handler, and clearing the property on any node clears it for all of them.

### Change

Move the assigned function and its listener onto the node. The two `ClrFunction` accessors stay on the prototype, shared as before; only the state they read and write is now looked up per node. The dictionary holding it is allocated lazily, so nodes without handlers are unchanged.

This also stops the prototype from holding on to the last function assigned anywhere in the document, which kept that closure - and everything it captured - alive for as long as the engine.

### Tests

Two tests were added to `FireEventTests`, both failing on `devel` and passing here:

* `ClickHandlerIsKeptPerElement` - two elements with different handlers keep their own identity and each fires only its own handler;
* `ClearingClickHandlerOfOneElementKeepsTheOther`.

Test results are otherwise unchanged: the same six pre-existing `net8.0` failures before and after (fixed by #111; the suite is green on `net462`/`net472`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik