### PR TITLE
Do not abandon a type's remaining properties after a method-like one

### DIFF
--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -169,8 +169,8 @@ namespace AngleSharp.Js
                         SetMethod(name, property.GetMethod);
                     }
 
-                    // methods were set, so finish processing
-                    return;
+                    // methods were set, so continue with the next property
+                    continue;
                 }
 
                 if (accessor == Accessors.Getter || accessor == Accessors.Setter || Array.Exists(names, m => m.Is("item")))


### PR DESCRIPTION
`SetNormalProperties` walks the declared properties of a type and registers each of them on the prototype. A property carrying `[DomAccessor(Accessors.Method)]` is registered as a method instead - and then the loop `return`s, so every property declared after it on the same type is silently never registered.

The intent reads as "this property is done, move on"; `continue` says that.

### Is anything lost today?

That depends on the order `Type.DeclaredProperties` happens to return members in, which is not specified. With the current AngleSharp DOM the only type with a method-like property is `INode` (`hasChildNodes`), and the one property that follows it carries no `[DomName]`, so nothing observable is missing right now.

So this is a latent defect rather than a visible one - but `INode` is in the type tree of every node prototype, and the next attributed property added after a method-like one would quietly disappear from the DOM.

### Tests

No behaviour change with today's DOM types, so there is nothing to assert that would fail on `devel`; I would rather say that than dress a no-op up as a regression test.

Test results are unchanged: the same six pre-existing `net8.0` failures before and after (fixed by #111; the suite is green on `net462`/`net472`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik