### PR TITLE
Parse import maps as JSON instead of interpolating them into script

### DIFF
--- a/src/AngleSharp.Js.Tests/EcmaTests.cs
+++ b/src/AngleSharp.Js.Tests/EcmaTests.cs
@@ -103,6 +103,34 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task ModuleScriptWithQuoteInImportMapShouldRun()
+        {
+            var config =
+                Configuration.Default
+                                .WithJs()
+                                .With(new MockHttpClientRequester(new Dictionary<string, string>()
+                                {
+                                    { "/example-module.js", "export function test() { document.getElementById('test').remove(); }" }
+                                }))
+                                .WithDefaultLoader(new LoaderOptions() { IsResourceLoadingEnabled = true });
+
+            var context = BrowsingContext.New(config);
+            var html = "<!doctype html><div id=test>Test</div><script type=importmap>{ \"imports\": { \"o'clock\": \"/example-module.js\" } }</script><script type=module>import { test } from \"o'clock\"; test();</script>";
+            var document = await context.OpenAsync(r => r.Content(html));
+            Assert.IsNull(document.GetElementById("test"));
+        }
+
+        [Test]
+        public async Task ImportMapContentIsNotEvaluatedAsScript()
+        {
+            var config = Configuration.Default.WithJs();
+            var context = BrowsingContext.New(config);
+            var html = "<!doctype html><div id=test>Test</div><script type=importmap>{ \"imports\": {} }'); document.getElementById('test').remove(); ('</script>";
+            var document = await context.OpenAsync(r => r.Content(html));
+            Assert.IsNotNull(document.GetElementById("test"));
+        }
+
+        [Test]
         public async Task ModuleScriptWithAbsoluteUrlImportMapShouldRun()
         {
             var config =

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -5,6 +5,7 @@ namespace AngleSharp.Js
     using AngleSharp.Text;
     using Jint;
     using Jint.Native;
+    using Jint.Native.Json;
     using Jint.Native.Object;
     using System;
     using System.Collections.Generic;
@@ -117,7 +118,10 @@ namespace AngleSharp.Js
 
         private JsValue LoadImportMap(String source)
         {
-            var importMap = _engine.Evaluate($"JSON.parse('{source}')").AsObject();
+            //  The source is page content, so it must be handed to a JSON parser rather
+            //  than pasted into a script: a single quote already breaks the parse, and
+            //  anything after a closing quote would run as script.
+            var importMap = new JsonParser(_engine).Parse(source).AsObject();
 
             if (importMap.TryGetValue("scopes", out var scopes))
             {


### PR DESCRIPTION
`LoadImportMap` builds the source string `JSON.parse('<page content>')` and evaluates it. The content of a `<script type="importmap">` element is page content, so this is both wrong and unsafe.

**Wrong:** an import map containing an apostrophe - a specifier such as `o'clock`, or any URL with one - terminates the string literal and fails to parse.

**Unsafe:** anything after a closing quote is no longer data. This element is not executable by definition, yet its content runs:

```html
<script type="importmap">{ "imports": {} }'); document.getElementById('test').remove(); ('</script>
```

On `devel` the element is removed.

### Change

Hand the content to Jint's JSON parser. Malformed content still raises a `SyntaxError`, exactly as the previous `JSON.parse` did.

### Tests

Two tests added to `EcmaTests`, both failing on `devel` and passing here:

* `ModuleScriptWithQuoteInImportMapShouldRun` - a specifier containing an apostrophe resolves;
* `ImportMapContentIsNotEvaluatedAsScript` - the payload above leaves the document alone.

Test results are otherwise unchanged: the same six pre-existing `net8.0` failures before and after (fixed by #111; the suite is green on `net462`/`net472`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik