### PR TITLE
Return the same console object for a window

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -68,5 +68,19 @@ namespace AngleSharp.Js.Tests
             var result = await "new DOMParser().parseFromString(`<div class='a b'></div>`, 'text/html').body.firstChild.classList[1]".EvalScriptAsync();
             Assert.AreEqual("b", result);
         }
+
+        [Test]
+        public async Task ConsoleIsTheSameObjectOnEveryAccess()
+        {
+            var result = await "window.console === window.console".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+
+        [Test]
+        public async Task ConsoleKeepsPropertiesAssignedToIt()
+        {
+            var result = await "(function () { window.console.marker = 'kept'; return window.console.marker; })()".EvalScriptAsync();
+            Assert.AreEqual("kept", result);
+        }
     }
 }

--- a/src/AngleSharp.Js/Dom/WindowExtensions.cs
+++ b/src/AngleSharp.Js/Dom/WindowExtensions.cs
@@ -7,6 +7,7 @@ namespace AngleSharp.Js.Dom
     using AngleSharp.Html.Dom;
     using AngleSharp.Js.Attributes;
     using System;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// Defines a set of extensions for the window object.
@@ -14,6 +15,9 @@ namespace AngleSharp.Js.Dom
     [DomExposed("Window")]
     public static class WindowExtensions
     {
+        private static readonly ConditionalWeakTable<IWindow, Console> Consoles =
+            new ConditionalWeakTable<IWindow, Console>();
+
         /// <summary>
         /// Posts a message.
         /// </summary>
@@ -34,7 +38,9 @@ namespace AngleSharp.Js.Dom
         public static IWindow Top(this IWindow window) => window.Document.Context?.Creator?.DefaultView;
 
         /// <summary>
-        /// Gets the console instance.
+        /// Gets the console instance. The same instance is returned for the same
+        /// window, so that `window.console === window.console` holds and anything
+        /// script puts on the console is still there on the next access.
         /// </summary>
         /// <param name="window"></param>
         /// <returns></returns>
@@ -42,7 +48,7 @@ namespace AngleSharp.Js.Dom
         [DomAccessor(Accessors.Getter)]
         public static Console Console(this IWindow window)
         {
-            return new Console(window);
+            return Consoles.GetValue(window, w => new Console(w));
         }
 
         /// <summary>


### PR DESCRIPTION
`window.console` builds a new `Console` on every access, so the identity a page observes is never stable:

```js
window.console === window.console   // false
window.console.marker = 1;
window.console.marker               // undefined
```

Every read also allocates the console, a DOM wrapper for it, and re-resolves the logger service from the browsing context.

### Change

Keep one console per window, in a `ConditionalWeakTable` so it does not keep the window alive.

### Tests

Two tests added to `DomTests`, both failing on `devel` and passing here: `ConsoleIsTheSameObjectOnEveryAccess` and `ConsoleKeepsPropertiesAssignedToIt`.

Rebased onto current `devel`. The suite is green on `net8.0`, `net462` and `net472` - 131 tests on `devel`, 133 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
