### PR TITLE
Register DOM prototype members only when the prototype is used

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -26,5 +26,33 @@ namespace AngleSharp.Js.Tests
             var result = await "new DOMParser().parseFromString(`<div><input/></div>`, 'text/html').body.firstChild.hasChildNodes()".EvalScriptAsync();
             Assert.AreEqual("True", result);
         }
+
+        [Test]
+        public async Task NumericIndexerOfHtmlCollectionYieldsTheElement()
+        {
+            var result = await "document.getElementsByTagName('script')[0].nodeName".EvalScriptAsync();
+            Assert.AreEqual("SCRIPT", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfHtmlCollectionOutOfRangeIsUndefined()
+        {
+            var result = await "typeof document.getElementsByTagName('script')[5]".EvalScriptAsync();
+            Assert.AreEqual("undefined", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfNodeListYieldsTheNode()
+        {
+            var result = await "new DOMParser().parseFromString(`<div><input/></div>`, 'text/html').body.childNodes[0].nodeName".EvalScriptAsync();
+            Assert.AreEqual("DIV", result);
+        }
+
+        [Test]
+        public async Task NumericIndexerOfTokenListYieldsTheToken()
+        {
+            var result = await "new DOMParser().parseFromString(`<div class='a b'></div>`, 'text/html').body.firstChild.classList[1]".EvalScriptAsync();
+            Assert.AreEqual("b", result);
+        }
     }
 }

--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -28,6 +28,20 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task PrototypeChainOfElementIsBuiltCompletely()
+        {
+            var result = await "(function () { var p = Object.getPrototypeOf(document.createElement('div')), t = []; while (p) { t.push(p[Symbol.toStringTag]); p = Object.getPrototypeOf(p); } return t.join(); })()".EvalScriptAsync();
+            Assert.AreEqual("HTMLDivElement,HTMLElement,Element,Node,EventTarget,", result);
+        }
+
+        [Test]
+        public async Task ConstructorPropertyOfPrototypeRefersBackToTheConstructor()
+        {
+            var result = await "HTMLDivElement.prototype.constructor === HTMLDivElement".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+
+        [Test]
         public async Task NumericIndexerOfHtmlCollectionYieldsTheElement()
         {
             var result = await "document.getElementsByTagName('script')[0].nodeName".EvalScriptAsync();

--- a/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
@@ -22,7 +22,19 @@ namespace AngleSharp.Js
             _instance = engine;
             FastSetProperty("toString", new PropertyDescriptor(toString, true, false, true));
             SetOwnProperty("prototype", new PropertyDescriptor(_objectPrototype, false, false, false));
-            _objectPrototype.FastSetProperty("constructor", new PropertyDescriptor(this, true, false, true));
+
+            var constructor = new PropertyDescriptor(this, true, false, true);
+
+            //  Every exposed type gets a constructor, so writing this directly would make
+            //  each of their prototypes register its members right away.
+            if (_objectPrototype is DomPrototypeInstance domPrototype)
+            {
+                domPrototype.DefineDeferredProperty("constructor", constructor);
+            }
+            else
+            {
+                _objectPrototype.FastSetProperty("constructor", constructor);
+            }
         }
 
         public DomConstructorInstance(EngineInstance engine, ConstructorInfo constructor)

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -16,31 +16,82 @@ namespace AngleSharp.Js
         private readonly String _name;
         private readonly EngineInstance _instance;
         private readonly Type _type;
+        private readonly Type _baseType;
 
+        private List<KeyValuePair<String, PropertyDescriptor>> _deferred;
+        private Boolean _membersSet;
         private MethodInfo _numericIndexer;
         private MethodInfo _stringIndexer;
 
         public DomPrototypeInstance(EngineInstance engine, Type type)
             : base(engine.Jint)
         {
-            var baseType = type.GetTypeInfo().BaseType ?? typeof(Object);
-            _name = type.GetOfficialName(baseType);
+            _baseType = type.GetTypeInfo().BaseType ?? typeof(Object);
+            _name = type.GetOfficialName(_baseType);
             _instance = engine;
             _type = type;
+        }
+
+        //  A document uses a handful of the DOM types an assembly exposes, but a prototype
+        //  is created for every one of them. Reflecting over the whole type tree is by far
+        //  the most expensive part of that, so it waits until the prototype is looked at.
+        //  Jint calls this before serving any property, and marks the instance initialized
+        //  beforehand, so the registration below can use the object as usual.
+        protected override void Initialize()
+        {
+            _membersSet = true;
 
             Set(GlobalSymbolRegistry.ToStringTag, _name);
 
-            SetAllMembers(type);
+            SetAllMembers(_type);
             SetExtensionMembers();
 
             //  DOM objects can have properties added dynamically
-            Prototype = engine.GetDomPrototype(baseType);
+            Prototype = _instance.GetDomPrototype(_baseType);
+
+            if (_deferred != null)
+            {
+                foreach (var property in _deferred)
+                {
+                    FastSetProperty(property.Key, property.Value);
+                }
+
+                _deferred = null;
+            }
+        }
+
+        //  The prototype link is only established once the members are known, so reading it
+        //  has to initialize as well - not every reader goes through a property lookup.
+        protected override ObjectInstance GetPrototypeOf()
+        {
+            EnsureInitialized();
+            return base.GetPrototypeOf();
+        }
+
+        /// <summary>
+        /// Defines a property on the prototype without forcing its members to be
+        /// registered. The property is applied after the members, so it keeps
+        /// overriding a member of the same name.
+        /// </summary>
+        public void DefineDeferredProperty(String name, PropertyDescriptor descriptor)
+        {
+            if (_membersSet)
+            {
+                FastSetProperty(name, descriptor);
+            }
+            else
+            {
+                _deferred = _deferred ?? new List<KeyValuePair<String, PropertyDescriptor>>();
+                _deferred.Add(new KeyValuePair<String, PropertyDescriptor>(name, descriptor));
+            }
         }
 
         public Boolean TryGetFromIndex(Object value, String index, out PropertyDescriptor result)
         {
             //  If we have a numeric indexer and the property is numeric
             result = default;
+
+            EnsureInitialized();
 
             if (_numericIndexer != null && Int32.TryParse(index, out var numericIndex))
             {

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -15,9 +15,10 @@ namespace AngleSharp.Js
     {
         private readonly String _name;
         private readonly EngineInstance _instance;
+        private readonly Type _type;
 
-        private PropertyInfo _numericIndexer;
-        private PropertyInfo _stringIndexer;
+        private MethodInfo _numericIndexer;
+        private MethodInfo _stringIndexer;
 
         public DomPrototypeInstance(EngineInstance engine, Type type)
             : base(engine.Jint)
@@ -25,6 +26,7 @@ namespace AngleSharp.Js
             var baseType = type.GetTypeInfo().BaseType ?? typeof(Object);
             _name = type.GetOfficialName(baseType);
             _instance = engine;
+            _type = type;
 
             Set(GlobalSymbolRegistry.ToStringTag, _name);
 
@@ -45,7 +47,7 @@ namespace AngleSharp.Js
                 try
                 {
                     var args = new Object[] { numericIndex };
-                    var orig = _numericIndexer.GetMethod.Invoke(value, args);
+                    var orig = _numericIndexer.Invoke(value, args);
                     result = new PropertyDescriptor(orig.ToJsValue(_instance), false, false, false);
                     return true;
                 }
@@ -70,7 +72,7 @@ namespace AngleSharp.Js
             if (_stringIndexer != null && !HasProperty(index))
             {
                 var args = new Object[] { index };
-                var valueAtIndex = _stringIndexer.GetMethod.Invoke(value, args);
+                var valueAtIndex = _stringIndexer.Invoke(value, args);
 
                 if (valueAtIndex == null)
                 {
@@ -229,17 +231,52 @@ namespace AngleSharp.Js
 
         private void SetIndexer(PropertyInfo property, ParameterInfo[] indexParameters)
         {
-            if (indexParameters.Length == 1)
+            if (indexParameters.Length != 1)
             {
-                if (indexParameters[0].ParameterType == typeof(Int32))
-                {
-                    _numericIndexer = property;
-                }
-                else if (indexParameters[0].ParameterType == typeof(String))
-                {
-                    _stringIndexer = property;
-                }
+                return;
             }
+
+            var getter = ResolveAccessor(property.GetMethod);
+
+            if (getter == null)
+            {
+                return;
+            }
+
+            if (indexParameters[0].ParameterType == typeof(Int32))
+            {
+                _numericIndexer = getter;
+            }
+            else if (indexParameters[0].ParameterType == typeof(String))
+            {
+                _stringIndexer = getter;
+            }
+        }
+
+        private MethodInfo ResolveAccessor(MethodInfo accessor)
+        {
+            //  An interface may re-implement a member of one of its own base interfaces
+            //  explicitly, e.g. "T IReadOnlyList<T>.this[Int32 index]" declared on an
+            //  IHtmlCollection<T>. Such a member is private and abstract - invoking it
+            //  reflectively throws an EntryPointNotFoundException because the actual
+            //  implementation lives in a different slot. Resolve it against the type the
+            //  prototype was created for, which is where the implementation can be found.
+            if (accessor == null || accessor.IsPublic)
+            {
+                return accessor;
+            }
+
+            var name = accessor.Name;
+            var simpleName = name.Substring(name.LastIndexOf('.') + 1);
+            var parameters = accessor.GetParameters();
+            var parameterTypes = new Type[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parameterTypes[i] = parameters[i].ParameterType;
+            }
+
+            return _type.GetRuntimeMethod(simpleName, parameterTypes) ?? accessor;
         }
 
         private void SetMethod(String name, MethodInfo method)


### PR DESCRIPTION
> Contains #111 as its first commit, because both touch `DomPrototypeInstance`'s fields. Merging #111 first leaves one commit here.

A prototype is created for every DOM type an assembly exposes - around 170 of them for AngleSharp alone - and its constructor reflects over the whole type tree of that type right away: properties, methods, events and extension methods, on every interface and base class, allocating a `ClrFunction` pair per member. A document that touches a dozen DOM types still pays for all of them before the first statement runs.

### Change

`ObjectInstance.Initialize` is exactly the hook for this: Jint calls it the first time an object is asked for a property, and marks the instance initialized before calling it, so the registration can use the object normally.

The constructor body moves there verbatim - same order, prototype link still established last, so member registration still sees exactly the properties it saw before (`SetMethod` and `SetExtensionMethods` probe `HasProperty` while the prototype chain is still the default one).

Two places needed adjusting so that laziness actually holds:

* the prototype link is now set during initialization, so reading it has to initialize too - `Object.getPrototypeOf` and `instanceof` reach it without going through a property lookup;
* every exposed type gets a constructor, and the constructor writes `constructor` onto its prototype, which would initialize all of them again. That write is deferred and applied at the end of initialization, exactly where the old code performed it.

### Effect

The test suite drops from ~20s to ~3s, which is the same work disappearing - every test builds at least one document. I have not put a number on a single document; that is the honest shape of the measurement I have.

### Verification

Behaviour is meant to be identical, so I checked the structure rather than a handful of properties: for ten different DOM object kinds (document, element, collection, token list, named node map, node list, window, `DOMParser`, ...) I dumped every prototype in the chain with its full own-property name set and its `Symbol.toStringTag`, plus the global object's own property names. The dump is byte-identical to `devel`.

Two tests added to `DomTests` for the parts that are easy to get wrong: the prototype chain of an element is complete and correctly tagged, and `HTMLDivElement.prototype.constructor === HTMLDivElement` (the deferred write).

`net462`, `net472` and `net8.0`: 124 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik