### PR TITLE
Cache parsed scripts instead of re-parsing them for every document

### DIFF
--- a/src/AngleSharp.Js.Tests/InteractionTests.cs
+++ b/src/AngleSharp.Js.Tests/InteractionTests.cs
@@ -114,6 +114,30 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task RunSameScriptSourceInSeveralDocumentsKeepsStateSeparate()
+        {
+            var html = "<!doctype html><span id=test>Test</span>";
+            var config = Configuration.Default.WithJs();
+            var source = "(function () { window.counter = (window.counter || 0) + 1; return window.counter; })()";
+            var first = await BrowsingContext.New(config).OpenAsync(m => m.Content(html));
+            var second = await BrowsingContext.New(config).OpenAsync(m => m.Content(html));
+
+            Assert.AreEqual(1.0, first.ExecuteScript(source));
+            Assert.AreEqual(1.0, second.ExecuteScript(source));
+            Assert.AreEqual(2.0, first.ExecuteScript(source));
+            Assert.AreEqual(2.0, second.ExecuteScript(source));
+        }
+
+        [Test]
+        public async Task RunScriptSnippetWithSyntaxErrorThrows()
+        {
+            var html = "<!doctype html><span id=test>Test</span>";
+            var config = Configuration.Default.WithJs();
+            var document = await BrowsingContext.New(config).OpenAsync(m => m.Content(html));
+            Assert.Throws<JavaScriptException>(() => document.ExecuteScript("function ("));
+        }
+
+        [Test]
         public async Task RunScriptAtPressingLink_Issue47()
         {
             var html = "<!doctype html><pre id=test></pre><a href=\"javascript:document.querySelector('#test').textContent='success';\">Test</a>";

--- a/src/AngleSharp.Js/Cache/ScriptCache.cs
+++ b/src/AngleSharp.Js/Cache/ScriptCache.cs
@@ -1,0 +1,54 @@
+namespace AngleSharp.Js.Cache
+{
+    using Acornima.Ast;
+    using Jint;
+    using Jint.Runtime;
+    using System;
+    using System.Collections.Concurrent;
+
+    /// <summary>
+    /// Caches the parsed and analyzed form of scripts. A prepared script is
+    /// documented by Jint as reusable and thread-safe, so the same one can serve
+    /// every document that runs the same source - a page loading a library ends up
+    /// parsing it once instead of once per document.
+    /// </summary>
+    static class ScriptCache
+    {
+        //  There is no bound on how many distinct scripts a process may see, so the
+        //  cache does not grow without end. The scripts worth keeping are the ones
+        //  seen first: libraries are referenced early and by many documents.
+        private const Int32 Capacity = 32;
+
+        private static readonly ConcurrentDictionary<String, Prepared<Script>> _scripts =
+            new ConcurrentDictionary<String, Prepared<Script>>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the prepared form of the given source. An invalid result means the
+        /// source could not be prepared and should be handed to the engine as text,
+        /// so that the engine reports the syntax error itself.
+        /// </summary>
+        public static Prepared<Script> GetOrCreate(String source)
+        {
+            if (_scripts.TryGetValue(source, out var prepared))
+            {
+                return prepared;
+            }
+
+            try
+            {
+                prepared = Engine.PrepareScript(source);
+            }
+            catch (ScriptPreparationException)
+            {
+                return default;
+            }
+
+            if (_scripts.Count < Capacity)
+            {
+                _scripts.TryAdd(source, prepared);
+            }
+
+            return prepared;
+        }
+    }
+}

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -2,6 +2,7 @@ namespace AngleSharp.Js
 {
     using AngleSharp.Dom;
     using AngleSharp.Io;
+    using AngleSharp.Js.Cache;
     using AngleSharp.Text;
     using Jint;
     using Jint.Native;
@@ -84,7 +85,7 @@ namespace AngleSharp.Js
 
         public ObjectInstance GetDomPrototype(Type type) => _prototypes.GetOrCreate(type, CreatePrototype);
 
-        public JsValue RunScript(String source, String type, String sourceUrl, JsValue context)
+        public JsValue RunScript(String source, String type, String sourceUrl)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -95,7 +96,10 @@ namespace AngleSharp.Js
             {
                 if (MimeTypeNames.IsJavaScript(type))
                 {
-                    return _engine.Evaluate(source);
+                    var prepared = ScriptCache.GetOrCreate(source);
+                    //  An invalid result means the source did not parse; hand it to the
+                    //  engine as text so the syntax error is reported as usual.
+                    return prepared.IsValid ? _engine.Evaluate(prepared) : _engine.Evaluate(source);
                 }
                 else if (type.Isi("importmap"))
                 {

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -209,12 +209,6 @@ namespace AngleSharp.Js
             apply.Invoke(engine, obj);
         }
 
-        public static JsValue RunScript(this EngineInstance engine, String source, String type, String sourceUrl) =>
-            engine.RunScript(source, type, sourceUrl, engine.Window);
-
-        public static JsValue RunScript(this EngineInstance engine, String source, String type, String sourceUrl, INode context) =>
-            engine.RunScript(source, type, sourceUrl, context.ToJsValue(engine));
-
         public static JsValue Call(this EngineInstance instance, MethodInfo method, JsValue thisObject, JsValue[] arguments)
         {
             if (method != null)


### PR DESCRIPTION
Every document gets its own engine, and `RunScript` hands the raw source to `Engine.Evaluate(string)`, which parses it from scratch. A page that loads a library therefore pays the full parse of that library once per document, even though the result is identical every time. The same applies to any host code that calls `ExecuteScript` with the same snippet repeatedly.

### Change

Prepare the script once and evaluate the prepared form. Jint documents a prepared script as *"reusable and thread-safe"*, so one entry can serve every document that runs the same source.

Sources that fail to prepare are handed to the engine as text, so a syntax error is still reported by the engine as a `JavaScriptException` and not turned into `ScriptPreparationException`.

The cache is capped, because nothing bounds how many distinct scripts a process may see; the entries kept are the ones encountered first, which is where shared libraries show up. Happy to change the number or the policy if you would rather have something else there.

This also drops `RunScript`'s `context` parameter and the overload that fed it - the parameter was never read, and the overload that converted a node for it had no callers. Both are internal.

### Tests

Two tests added to `InteractionTests` for the properties this change must not break. They pass on `devel` too - they are guards, not regression tests:

* `RunSameScriptSourceInSeveralDocumentsKeepsStateSeparate` - the same source evaluated in two documents keeps per-document state, and stays correct across repeated evaluation;
* `RunScriptSnippetWithSyntaxErrorThrows`.

Test results are otherwise unchanged: the same six pre-existing `net8.0` failures before and after (fixed by #111; the suite is green on `net462`/`net472`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik