### PR TITLE
Stop redoing per-method reflection on every call from script

### DIFF
--- a/src/AngleSharp.Js.Tests/FireEventTests.cs
+++ b/src/AngleSharp.Js.Tests/FireEventTests.cs
@@ -290,6 +290,31 @@ document.onreadystatechange = function() {
         }
 
         [Test]
+        public async Task SetTimeoutWithSeveralDifferentFunctions()
+        {
+            var service = new JsScriptingService();
+            var cfg = Configuration.Default.With(service).WithEventLoop();
+            var html = @"<!doctype html>
+<html>
+<body>
+<script>
+var log = [];
+setTimeout(function () { log.push('a'); }, 0);
+setTimeout(function () { log.push('b'); }, 0);
+setTimeout(function () { log.push('c'); }, 0);
+</script>
+</body>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html))
+                .WhenStable();
+            var log = service.GetOrCreateJint(document).GetValue("log").AsArray();
+
+            Assert.AreEqual(3.0, log.Get("length").AsNumber());
+            Assert.AreEqual("a", log.Get("0").AsString());
+            Assert.AreEqual("b", log.Get("1").AsString());
+            Assert.AreEqual("c", log.Get("2").AsString());
+        }
+
+        [Test]
         public async Task SetTimeoutWithStringAsFunction()
         {
             var service = new JsScriptingService();

--- a/src/AngleSharp.Js/Cache/MethodCache.cs
+++ b/src/AngleSharp.Js/Cache/MethodCache.cs
@@ -1,0 +1,70 @@
+namespace AngleSharp.Js.Cache
+{
+    using AngleSharp.Attributes;
+    using AngleSharp.Dom;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
+
+    /// <summary>
+    /// Describes what building the arguments of a method needs to know about it.
+    /// All of it is fixed by the method itself, so it is worked out once instead of
+    /// on every call from script.
+    /// </summary>
+    sealed class MethodDescription
+    {
+        private static readonly ConcurrentDictionary<MethodBase, MethodDescription> _descriptions =
+            new ConcurrentDictionary<MethodBase, MethodDescription>();
+
+        private MethodDescription(MethodBase method)
+        {
+            var parameters = method.GetParameters();
+            var descriptions = new ParameterDescription[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                descriptions[i] = new ParameterDescription(parameters[i]);
+            }
+
+            Parameters = descriptions;
+            InitDict = method.GetCustomAttribute<DomInitDictAttribute>();
+            TakesWindow = parameters.Length > 0 && parameters[0].ParameterType == typeof(IWindow);
+            TakesParamArray = parameters.Length > 0 &&
+                parameters[parameters.Length - 1].GetCustomAttribute<ParamArrayAttribute>() != null;
+        }
+
+        public static MethodDescription Of(MethodBase method) =>
+            _descriptions.GetOrAdd(method, m => new MethodDescription(m));
+
+        public ParameterDescription[] Parameters { get; }
+
+        public DomInitDictAttribute InitDict { get; }
+
+        public Boolean TakesWindow { get; }
+
+        public Boolean TakesParamArray { get; }
+    }
+
+    /// <summary>
+    /// The parts of a <see cref="ParameterInfo"/> that are read when arguments are
+    /// built. Reading them from reflection means walking metadata every time.
+    /// </summary>
+    readonly struct ParameterDescription
+    {
+        public ParameterDescription(ParameterInfo parameter)
+        {
+            Name = parameter.Name;
+            ParameterType = parameter.ParameterType;
+            IsOptional = parameter.IsOptional;
+            DefaultValue = parameter.IsOptional ? parameter.DefaultValue : null;
+        }
+
+        public String Name { get; }
+
+        public Type ParameterType { get; }
+
+        public Boolean IsOptional { get; }
+
+        public Object DefaultValue { get; }
+    }
+}

--- a/src/AngleSharp.Js/Extensions/DomDelegates.cs
+++ b/src/AngleSharp.Js/Extensions/DomDelegates.cs
@@ -7,6 +7,7 @@ namespace AngleSharp.Js
     using Jint.Native.Function;
     using Jint.Runtime;
     using System;
+    using System.Collections.Concurrent;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
@@ -16,11 +17,20 @@ namespace AngleSharp.Js
         private static readonly Type[] ToCallbackSignature = new[] { typeof(Function), typeof(EngineInstance) };
         private static readonly Type[] ToJsValueSignature = new[] { typeof(Object), typeof(EngineInstance) };
 
+        //  Both of these depend on the delegate type alone, so they survive the conversion
+        //  they were built for: turning a function into a delegate is otherwise a reflection
+        //  lookup plus an expression tree compilation, every single time.
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _converters =
+            new ConcurrentDictionary<Type, MethodInfo>();
+
+        private static readonly ConcurrentDictionary<Type, Delegate> _factories =
+            new ConcurrentDictionary<Type, Delegate>();
+
         public static Delegate ToDelegate(this Type type, Function function, EngineInstance engine)
         {
             if (type != typeof(DomEventHandler))
             {
-                var method = typeof(DomDelegates).GetRuntimeMethod("ToCallback", ToCallbackSignature).MakeGenericMethod(type);
+                var method = _converters.GetOrAdd(type, CreateConverter);
                 return method.Invoke(null, new Object[] { function, engine }) as Delegate;
             }
 
@@ -45,6 +55,15 @@ namespace AngleSharp.Js
 
         public static T ToCallback<T>(this Function function, EngineInstance engine)
         {
+            var factory = (Func<Function, EngineInstance, T>)_factories.GetOrAdd(typeof(T), _ => CreateFactory<T>());
+            return factory.Invoke(function, engine);
+        }
+
+        private static MethodInfo CreateConverter(Type type) =>
+            typeof(DomDelegates).GetRuntimeMethod("ToCallback", ToCallbackSignature).MakeGenericMethod(type);
+
+        private static Func<Function, EngineInstance, T> CreateFactory<T>()
+        {
             var methodInfo = typeof(T).GetRuntimeMethods().First(m => m.Name == "Invoke");
             var convert = typeof(EngineExtensions).GetRuntimeMethod("ToJsValue", ToJsValueSignature);
             var mps = methodInfo.GetParameters();
@@ -55,15 +74,16 @@ namespace AngleSharp.Js
                 parameters[i] = Expression.Parameter(mps[i].ParameterType, mps[i].Name);
             }
 
-            var objExpr = Expression.Constant(function);
-            var engineExpr = Expression.Constant(engine);
+            var objExpr = Expression.Parameter(typeof(Function), "function");
+            var engineExpr = Expression.Parameter(typeof(EngineInstance), "engine");
             var call = Expression.Call(objExpr, "Call", new Type[0], new Expression[]
             {
                 Expression.Call(convert, parameters[0], engineExpr),
                 Expression.NewArrayInit(typeof(JsValue), parameters.Skip(1).Select(m => Expression.Call(convert, m, engineExpr)).ToArray())
             });
 
-            return Expression.Lambda<T>(call, parameters).Compile();
+            var callback = Expression.Lambda<T>(call, parameters);
+            return Expression.Lambda<Func<Function, EngineInstance, T>>(callback, objExpr, engineExpr).Compile();
         }
     }
 }

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -10,7 +10,6 @@ namespace AngleSharp.Js
     using Jint.Runtime.Descriptors;
     using Jint.Runtime.Interop;
     using System;
-    using System.Collections.Generic;
     using System.Reflection;
 
     static class EngineExtensions
@@ -72,13 +71,14 @@ namespace AngleSharp.Js
 
         public static Object[] BuildArgs(this EngineInstance context, MethodBase method, JsValue[] arguments)
         {
-            var parameters = method.GetParameters();
-            var initDict = method.GetCustomAttribute<DomInitDictAttribute>();
+            var description = MethodDescription.Of(method);
+            var parameters = description.Parameters;
+            var initDict = description.InitDict;
             var max = parameters.Length;
             var args = new Object[max];
             var offset = 0;
 
-            if (parameters.Length > 0 && parameters[0].ParameterType == typeof(IWindow))
+            if (description.TakesWindow)
             {
                 if (arguments.Length == 0 || arguments[0].FromJsValue() is IWindow == false)
                 {
@@ -86,7 +86,7 @@ namespace AngleSharp.Js
                 }
             }
 
-            if (max > 0 && parameters[max - 1].GetCustomAttribute<ParamArrayAttribute>() != null)
+            if (description.TakesParamArray)
             {
                 max--;
             }
@@ -137,7 +137,7 @@ namespace AngleSharp.Js
             return args;
         }
 
-        private static JsValue[] ExpandInitDict(JsValue[] arguments, ParameterInfo[] parameters, DomInitDictAttribute initDict, Int32 max, Int32 offset)
+        private static JsValue[] ExpandInitDict(JsValue[] arguments, ParameterDescription[] parameters, DomInitDictAttribute initDict, Int32 max, Int32 offset)
         {
             var newArgs = new JsValue[max - offset];
             var end = initDict.Offset - offset;
@@ -234,12 +234,10 @@ namespace AngleSharp.Js
                 {
                     if (method.IsStatic)
                     {
-                        var newArgs = new List<JsValue>
-                        {
-                            nodeInstance,
-                        };
-                        newArgs.AddRange(arguments);
-                        var parameters = instance.BuildArgs(method, newArgs.ToArray());
+                        var newArgs = new JsValue[arguments.Length + 1];
+                        newArgs[0] = nodeInstance;
+                        Array.Copy(arguments, 0, newArgs, 1, arguments.Length);
+                        var parameters = instance.BuildArgs(method, newArgs);
                         return method.Invoke(null, parameters).ToJsValue(instance);
                     }
                     else


### PR DESCRIPTION
Two things on the interop path repeat work that is fixed by the member being called.

**`BuildArgs`**, which runs for every DOM property read, property write and method call, does per call:

* `MethodBase.GetParameters()` - which hands out a fresh copy of the parameter array;
* `GetCustomAttribute<DomInitDictAttribute>()` and `GetCustomAttribute<ParamArrayAttribute>()`, each of which walks metadata and materialises an attribute;
* `IsOptional` / `DefaultValue` / `ParameterType` off each `ParameterInfo`.

None of that can change between calls. It is now worked out once per method and kept in a `MethodDescription`.

**`ToDelegate` / `ToCallback`**, which run whenever a script function is passed to a CLR delegate parameter (`setTimeout`, callbacks on DOM APIs), resolve and close a generic method and then compile an expression tree - for every conversion. Both depend only on the delegate type. The expression is reshaped into a factory taking the function and the engine as parameters, so one compiled factory serves every conversion to that delegate type.

`Call` also built a `List<JsValue>` and copied it to an array to prepend the receiver for static methods; it now fills the array directly.

### What this does not do

The actual invocation is still `MethodInfo.Invoke`. Replacing it with compiled delegates is the bigger win, but it changes the exception contract that the surrounding code depends on - `TryGetFromIndex` distinguishes an out-of-range index by unwrapping `TargetInvocationException`, and `EngineExtensions.Call` maps it to a `JavaScriptException` - and it needs guards for members that cannot be compiled. That is a separate change and I would rather it arrive with numbers behind it.

### Tests

No behaviour change: the same values are computed, just not repeatedly.

`SetTimeoutWithSeveralDifferentFunctions` was added to `FireEventTests` because the delegate cache has an obvious wrong version - caching the compiled callback rather than the factory would make all three timeouts run the first function. It passes on `devel` too.

Test results are otherwise unchanged: the same six pre-existing `net8.0` failures before and after (fixed by #111; the suite is green on `net462`/`net472`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik