### PR TITLE
Update Jint to 4.14.0

### DIFF
--- a/src/AngleSharp.Js/AngleSharp.Js.csproj
+++ b/src/AngleSharp.Js/AngleSharp.Js.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.0" />
-    <PackageReference Include="Jint" Version="4.1.0" />
+    <PackageReference Include="Jint" Version="4.14.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">


### PR DESCRIPTION
Thirteen minor versions of engine fixes and performance work since 4.1.0, with no source changes needed here.

Verified on all target frameworks: `net462`, `net472` and `net8.0` build clean and run the test suite with exactly the same results as 4.1.0 - the six `net8.0` failures on `devel` (fixed by #111) and nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik