### PR TITLE
Build the constructor of an exposed type when script first names it

### DIFF
--- a/src/AngleSharp.Js.Tests/DeferredConstructorTests.cs
+++ b/src/AngleSharp.Js.Tests/DeferredConstructorTests.cs
@@ -1,0 +1,141 @@
+﻿namespace AngleSharp.Js.Tests
+{
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The constructor of an exposed type is only built once script reads the property it
+    /// is published under, so these cover what a reader is entitled to see either way.
+    /// </summary>
+    [TestFixture]
+    public class DeferredConstructorTests
+    {
+        [Test]
+        public async Task ConstructorIsSameObjectOnWindowAndGlobal()
+        {
+            var result = await "String(window.HTMLDivElement === HTMLDivElement)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorIsSameObjectOnEveryRead()
+        {
+            var result = await "String((function () { var a = HTMLDivElement; var b = window.HTMLDivElement; return a === b && a === HTMLDivElement; })())".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorIsFunction()
+        {
+            var result = await "typeof HTMLDivElement".EvalScriptAsync();
+            Assert.AreEqual("function", result);
+        }
+
+        [Test]
+        public async Task UnreadConstructorIsStillOwnPropertyOfWindow()
+        {
+            var result = await "String(window.hasOwnProperty('HTMLTableColElement'))".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task UnreadConstructorIsStillEnumerable()
+        {
+            var result = await "String(Object.keys(window).indexOf('HTMLTableColElement') !== -1)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task UnreadConstructorIsStillFoundByForIn()
+        {
+            var result = await "String((function () { for (var k in window) { if (k === 'HTMLTableColElement') { return true; } } return false; })())".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorKeepsItsAttributes()
+        {
+            var result = await "(function () { var d = Object.getOwnPropertyDescriptor(window, 'HTMLDivElement'); return d.writable + ',' + d.enumerable + ',' + d.configurable; })()".EvalScriptAsync();
+            Assert.AreEqual("false,true,false", result);
+        }
+
+        [Test]
+        public async Task DescriptorValueIsTheConstructor()
+        {
+            var result = await "String(Object.getOwnPropertyDescriptor(window, 'HTMLDivElement').value === HTMLDivElement)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ReadingAConstructorDoesNotChangeTheKeysOfWindow()
+        {
+            var result = await "String((function () { var before = Object.keys(window).length; var c = HTMLDivElement; return before === Object.keys(window).length; })())".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructedInstanceIsInstanceOfItsConstructor()
+        {
+            var result = await "String(new CustomEvent('foo') instanceof CustomEvent)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorBuildsInstances()
+        {
+            var result = await "new CustomEvent('foo').type".EvalScriptAsync();
+            Assert.AreEqual("foo", result);
+        }
+
+        [Test]
+        public async Task PrototypePointsBackAtItsConstructor()
+        {
+            var result = await "String(HTMLDivElement.prototype.constructor === HTMLDivElement)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        //  Reaching a prototype through an instance is the one path that never names the
+        //  type, so it is the one that has to pull the constructor in by itself.
+        [Test]
+        public async Task InstanceReportsItsConstructorWhenTheNameWasNeverRead()
+        {
+            var result = await "screen.constructor.name".EvalScriptAsync();
+            Assert.AreEqual("Screen", result);
+        }
+
+        [Test]
+        public async Task InstanceReportsTheSameConstructorTheWindowPublishes()
+        {
+            var result = await "String(screen.constructor === Screen)".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorIsNotWritable()
+        {
+            var result = await "String((function () { var before = HTMLDivElement; window.HTMLDivElement = 5; return window.HTMLDivElement === before; })())".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorIsNotConfigurable()
+        {
+            var result = await "String((delete window.HTMLDivElement) === false && typeof HTMLDivElement === 'function')".EvalScriptAsync();
+            Assert.AreEqual("true", result);
+        }
+
+        [Test]
+        public async Task ConstructorStringifiesAsNativeCode()
+        {
+            var result = await "String(HTMLDivElement)".EvalScriptAsync();
+            Assert.AreEqual("function HTMLDivElement() { [native code] }", result);
+        }
+
+        [Test]
+        public async Task NonConstructableTypeStillRejectsNew()
+        {
+            var result = await "(function () { try { new Node(); return 'no throw'; } catch (e) { return 'threw'; } })()".EvalScriptAsync();
+            Assert.AreEqual("threw", result);
+        }
+    }
+}

--- a/src/AngleSharp.Js/Cache/CreatorCache.cs
+++ b/src/AngleSharp.Js/Cache/CreatorCache.cs
@@ -12,11 +12,16 @@ namespace AngleSharp.Js.Cache
 {
     static class CreatorCache
     {
-        private static readonly ConcurrentDictionary<Type, Action<EngineInstance, ObjectInstance>> _constructorActions = new();
+        private static readonly ConcurrentDictionary<Type, ConstructorDefinition> _constructorDefinitions = new();
 
-        public static Action<EngineInstance, ObjectInstance> GetConstructorAction(this Type type)
+        /// <summary>
+        /// Gets what is needed to build the constructor object for a type, or null if the
+        /// type is not exposed as one. The answer depends on the type alone, so the null
+        /// is cached as well - most exported types do not get a constructor.
+        /// </summary>
+        public static ConstructorDefinition GetConstructorDefinition(this Type type)
         {
-            if (!_constructorActions.TryGetValue(type, out var action))
+            if (!_constructorDefinitions.TryGetValue(type, out var definition))
             {
                 var ti = type.GetTypeInfo();
                 var names = ti.GetCustomAttributes<DomNameAttribute>();
@@ -25,21 +30,13 @@ namespace AngleSharp.Js.Cache
                 if (name != null && !ti.IsEnum)
                 {
                     var info = ti.DeclaredConstructors.FirstOrDefault(m => m.GetCustomAttributes<DomConstructorAttribute>().Any());
-                    action = (engine, obj) =>
-                    {
-                        var constructor = info != null ? new DomConstructorInstance(engine, info) : new DomConstructorInstance(engine, type);
-                        obj.FastSetProperty(name.OfficialName, new PropertyDescriptor(constructor, false, true, false));
-                    };
-                }
-                else
-                {
-                    action = (e, o) => { };
+                    definition = new ConstructorDefinition(type, name.OfficialName, info);
                 }
 
-                _constructorActions.TryAdd(type, action);
+                _constructorDefinitions.TryAdd(type, definition);
             }
 
-            return action;
+            return definition;
         }
 
         private static readonly ConcurrentDictionary<Type, Action<EngineInstance, ObjectInstance>> _constructorFunctionActions = new();
@@ -110,5 +107,36 @@ namespace AngleSharp.Js.Cache
 
             return action;
         }
+    }
+
+    /// <summary>
+    /// Everything the constructor object of a type is built from. The reflection behind it
+    /// is the same for every engine, so it is resolved once and kept by
+    /// <see cref="CreatorCache"/> - only the object built from it belongs to an engine.
+    /// </summary>
+    sealed class ConstructorDefinition
+    {
+        public ConstructorDefinition(Type type, String name, ConstructorInfo info)
+        {
+            Type = type;
+            Name = name;
+            Info = info;
+        }
+
+        /// <summary>
+        /// Gets the type the constructor creates instances of.
+        /// </summary>
+        public Type Type { get; }
+
+        /// <summary>
+        /// Gets the name the constructor is exposed under.
+        /// </summary>
+        public String Name { get; }
+
+        /// <summary>
+        /// Gets the constructor to invoke, or null if the type cannot be constructed from
+        /// script - naming it is still legal, calling it is not.
+        /// </summary>
+        public ConstructorInfo Info { get; }
     }
 }

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -86,6 +86,19 @@ namespace AngleSharp.Js
 
         public ObjectInstance GetDomPrototype(Type type) => _prototypes.GetOrCreate(type, CreatePrototype);
 
+        /// <summary>
+        /// Gets the constructor object of the given type, building it on first ask. The
+        /// prototype keeps it, so that naming the type and reading "constructor" off one of
+        /// its instances arrive at the same object.
+        /// </summary>
+        public DomConstructorInstance GetDomConstructor(ConstructorDefinition definition)
+        {
+            //  Only the prototype of System.Object is not one of ours, and that type is not
+            //  exposed as a constructor, so it never reaches this point.
+            var prototype = (DomPrototypeInstance)GetDomPrototype(definition.Type);
+            return prototype.GetConstructor(definition);
+        }
+
         public JsValue RunScript(String source, String type, String sourceUrl)
         {
             if (string.IsNullOrEmpty(type))

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -193,8 +193,12 @@ namespace AngleSharp.Js
 
         public static void AddConstructor(this EngineInstance engine, ObjectInstance obj, Type type)
         {
-            var apply = type.GetConstructorAction();
-            apply.Invoke(engine, obj);
+            var definition = type.GetConstructorDefinition();
+
+            if (definition != null)
+            {
+                obj.FastSetProperty(definition.Name, new DomConstructorDescriptor(engine, definition));
+            }
         }
 
         public static void AddConstructorFunction(this EngineInstance engine, ObjectInstance obj, Type type)

--- a/src/AngleSharp.Js/Proxies/DomConstructorDescriptor.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorDescriptor.cs
@@ -1,0 +1,37 @@
+namespace AngleSharp.Js
+{
+    using AngleSharp.Js.Cache;
+    using Jint.Native;
+    using Jint.Runtime.Descriptors;
+
+    /// <summary>
+    /// The property an exposed type is published under on the window and on the global
+    /// object. A document names a handful of the types an assembly exposes, but a property
+    /// is registered for every one of them, so the constructor object behind it is only
+    /// built once script reads the property.
+    /// </summary>
+    sealed class DomConstructorDescriptor : PropertyDescriptor
+    {
+        private readonly EngineInstance _instance;
+        private readonly ConstructorDefinition _definition;
+        private JsValue _resolved;
+
+        //  The attributes an eagerly written constructor had: enumerable, but neither
+        //  writable nor configurable. CustomJsValue is what routes a read through
+        //  CustomValue below; Jint reads that flag on every access instead of taking a
+        //  copy of the value, so the descriptor keeps working once one of the engine's
+        //  property caches has taken hold of it.
+        public DomConstructorDescriptor(EngineInstance instance, ConstructorDefinition definition)
+            : base(PropertyFlag.OnlyEnumerable | PropertyFlag.CustomJsValue)
+        {
+            _instance = instance;
+            _definition = definition;
+        }
+
+        protected override JsValue CustomValue
+        {
+            get => _resolved ?? (_resolved = _instance.GetDomConstructor(_definition));
+            set => _resolved = value;
+        }
+    }
+}

--- a/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
@@ -1,11 +1,11 @@
 namespace AngleSharp.Js
 {
+    using AngleSharp.Js.Cache;
     using Jint.Native;
     using Jint.Native.Object;
     using Jint.Runtime;
     using Jint.Runtime.Descriptors;
     using Jint.Runtime.Interop;
-    using System;
     using System.Reflection;
 
     sealed class DomConstructorInstance : Constructor
@@ -14,12 +14,13 @@ namespace AngleSharp.Js
         private readonly EngineInstance _instance;
         private readonly ObjectInstance _objectPrototype;
 
-        public DomConstructorInstance(EngineInstance engine, Type type)
-            : base(engine.Jint, type.GetOfficialName())
+        public DomConstructorInstance(EngineInstance engine, ConstructorDefinition definition)
+            : base(engine.Jint, definition.Name)
         {
             var toString = new ClrFunction(Engine, "toString", ToString);
-            _objectPrototype = engine.GetDomPrototype(type);
+            _objectPrototype = engine.GetDomPrototype(definition.Type);
             _instance = engine;
+            _constructor = definition.Info;
             FastSetProperty("toString", new PropertyDescriptor(toString, true, false, true));
             SetOwnProperty("prototype", new PropertyDescriptor(_objectPrototype, false, false, false));
 
@@ -35,12 +36,6 @@ namespace AngleSharp.Js
             {
                 _objectPrototype.FastSetProperty("constructor", constructor);
             }
-        }
-
-        public DomConstructorInstance(EngineInstance engine, ConstructorInfo constructor)
-            : this(engine, constructor.DeclaringType)
-        {
-            _constructor = constructor;
         }
 
         public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -1,6 +1,7 @@
 namespace AngleSharp.Js
 {
     using AngleSharp.Attributes;
+    using AngleSharp.Js.Cache;
     using AngleSharp.Text;
     using Jint.Native.Object;
     using Jint.Native.Symbol;
@@ -20,6 +21,7 @@ namespace AngleSharp.Js
 
         private List<KeyValuePair<String, PropertyDescriptor>> _deferred;
         private Boolean _membersSet;
+        private DomConstructorInstance _constructor;
         private MethodInfo _numericIndexer;
         private MethodInfo _stringIndexer;
 
@@ -58,7 +60,25 @@ namespace AngleSharp.Js
 
                 _deferred = null;
             }
+
+            //  It is the constructor object that registers "constructor" here, and it is
+            //  only built once script names the type. A prototype reached through an
+            //  instance instead - the usual way - would otherwise lack the property.
+            var definition = _type.GetConstructorDefinition();
+
+            if (definition != null)
+            {
+                GetConstructor(definition);
+            }
         }
+
+        /// <summary>
+        /// Gets the constructor object of the type this prototype belongs to, building it
+        /// on first ask. Holding it here is what keeps the one script reads off the window
+        /// and the one an instance reports as its "constructor" the same object.
+        /// </summary>
+        public DomConstructorInstance GetConstructor(ConstructorDefinition definition) =>
+            _constructor ?? (_constructor = new DomConstructorInstance(_instance, definition));
 
         //  The prototype link is only established once the members are known, so reading it
         //  has to initialize as well - not every reader goes through a property lookup.


### PR DESCRIPTION
Follow-up to the recent perf batch, and the last structural item from #72.

Setting up an engine gave every exposed type a constructor object: 178 of them, each with its own prototype link, `toString` function and property descriptors. A document names a handful. The reflection deciding *what* to build was already cached per type by `CreatorCache`; the objects built from it are engine-affine and were not.

The property is still registered for every type, with the attributes it had — `PropertyFlag.OnlyEnumerable` is bit-for-bit what `new PropertyDescriptor(value, false, true, false)` produced — so enumerating the window is unchanged. Only the object behind the property waits for the first read.

### `constructor` had to move

`DomConstructorInstance`'s ctor is what installs `constructor` on the type's prototype. Deferring naively would make `screen.constructor` `undefined`, because an object can reach script without its global name ever being read. So the prototype now owns its constructor and pulls it in at the end of `Initialize()`; reading the name off the window and reading `constructor` off an instance still arrive at the same object.

`AddConstructorFunctions` and `AddInstances` stay eager on purpose — they cover one type each (`Image`, `Screen`), so deferring them would add paths for no measurable gain.

### Numbers

The reported loop from #72 — 100 engines, all retained — net8.0, workstation GC, serial alternating runs:

| | before | after |
| --- | --- | --- |
| median per engine | 2.89 / 2.96 ms | **1.82 / 1.88 ms** (−36%) |
| per retained engine | 398.3 KB | **187.5 KB** (−53%) |
| 100 engines | 38.9 MB | **18.3 MB** |
| total allocation over the run | 100.4 MB | **60.5 MB** |

For 100 documents that actually run a script (build 50 elements, `querySelectorAll`, `new CustomEvent`, `dispatchEvent`): 8.28 → 7.68 ms, 735.0 → 527.2 KB per instance. The absolute saving is the same as in the bare case — a real page names two or three constructors, so the win does not erode.

Two things this does **not** do, stated plainly:

- **Cold start is unchanged.** The first engine in a process is 184.2 → 183.2 ms (n=5, overlapping ranges — noise). That cost is JIT plus first-time reflection over the type tree; the constructor loop was ~1 ms of it. The win is entirely in second-and-later engines and in retained memory.
- **These globals no longer enter Jint's global-identifier inline cache.** `PropertyFlag.CustomJsValue` cannot be cleared after materialization from outside Jint, and self-replacing the descriptor would mutate the property dictionary while `Object.values(window)` iterates it. Measured worst case, 2M reads of `HTMLDivElement`: 82.4/81.1 ms before vs 83.3/80.9 ms after — no regression, but it is a real property of the mechanism.

`PropertyFlag.CustomJsValue` is the hook Jint documents as surviving its read inline caches (`UnwrapJsValue` re-reads the flag on every access rather than snapshotting the value); overriding `Get` would not have been safe. Verified against the 4.14.0 tag, which is what this package consumes.

### Tests

133/133 → 151/151 on net8.0, net462 and net472, warning-clean on all four TFMs.

The 18 new tests in `DeferredConstructorTests` also pass against unmodified `devel` — they pin existing contract rather than asserting the new behaviour into existence. Separately, a fingerprint over all 180 window own-property names, all 373 `globalThis` names, `Object.keys`/`for...in` counts, descriptor attributes, identity, `instanceof`, `typeof`, delete/assign semantics and `.constructor` for 20 different objects is byte-identical before and after.
