### PR TITLE
Fix invoking JavaScript with C# DOM arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Released on ?.
 
 - Fixed `StackOverflowException` from deeply recursive scripts (#75) @lahma
+- Fixed invoking JavaScript functions with DOM objects created in C#, which reached script as a plain CLR wrapper instead of as the DOM object (#76)
 - Fixed usage of document ready state (#87) @Sebbs128
 - Fixed `HasChildNodes` is now exposed as a method to DOM (#106) @arekdygas
 - Fixed missing `parent` on Window objects (#68)

--- a/src/AngleSharp.Js.Tests/InteractionTests.cs
+++ b/src/AngleSharp.Js.Tests/InteractionTests.cs
@@ -2,8 +2,10 @@ namespace AngleSharp.Js.Tests
 {
     using AngleSharp.Dom;
     using AngleSharp.Html.Dom;
+    using AngleSharp.Html.Parser;
     using AngleSharp.Scripting;
     using Jint;
+    using Jint.Native;
     using Jint.Runtime;
     using NUnit.Framework;
     using System;
@@ -36,6 +38,59 @@ namespace AngleSharp.Js.Tests
             var result = engine.Invoke(square, 4);
             Assert.AreEqual(Types.Number, result.Type);
             Assert.AreEqual(16.0, result.AsNumber());
+        }
+
+        [Test]
+        public async Task InvokeFunctionWithCSharpCreatedElement()
+        {
+            var service = new JsScriptingService();
+            var cfg = Configuration.Default.With(service);
+            var html = "<!doctype html><script>function f1(element) { document.body.appendChild(element); }</script>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+            var engine = service.GetOrCreateJint(document);
+            var section = document.CreateElement("section");
+            var f1 = engine.GetValue("f1");
+            var jsSection = JsValue.FromObject(engine, section);
+
+            engine.Invoke(f1, jsSection);
+
+            Assert.AreSame(section, document.Body.LastElementChild);
+            //  One node, one JS object: were a hand-over to mint a fresh proxy, the expandos and
+            //  the event handlers script attached through the previous one would be lost.
+            Assert.AreSame(jsSection, JsValue.FromObject(engine, section));
+            Assert.AreSame(jsSection, engine.Evaluate("document.body.lastElementChild"));
+        }
+
+        [Test]
+        public async Task InvokeFunctionWithCSharpCreatedElementUsesDomMembers()
+        {
+            var service = new JsScriptingService();
+            var cfg = Configuration.Default.With(service);
+            var html = "<!doctype html><script>function f1(element) { element.textContent = element.tagName; }</script>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+            var engine = service.GetOrCreateJint(document);
+            var section = document.CreateElement("section");
+
+            engine.Invoke(engine.GetValue("f1"), section);
+
+            Assert.AreEqual("SECTION", section.TextContent);
+        }
+
+        [Test]
+        public async Task ExternalNonDomObjectKeepsItsClrMembers()
+        {
+            //  A parser is an EventTarget, but it is not part of the DOM - a host object reaches
+            //  script the way every other host object does, through its CLR members.
+            var service = new JsScriptingService();
+            service.External.Add("parser", new HtmlParser());
+            var cfg = Configuration.Default.With(service);
+            var html = "<!doctype html><script></script>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+            var engine = service.GetOrCreateJint(document);
+
+            var result = engine.Evaluate("typeof parser.ParseDocument");
+
+            Assert.AreEqual("function", result.AsString());
         }
 
         [Test]

--- a/src/AngleSharp.Js/Cache/PrototypeTypeCache.cs
+++ b/src/AngleSharp.Js/Cache/PrototypeTypeCache.cs
@@ -22,6 +22,30 @@ namespace AngleSharp.Js.Cache
     {
         private static readonly ConcurrentDictionary<Assembly, IReadOnlyDictionary<String, Type>> _definingTypes = new();
         private static readonly ConcurrentDictionary<Assembly, IReadOnlyDictionary<String, Type>> _exposedTypes = new();
+        private static readonly ConcurrentDictionary<Type, Boolean> _domTypes = new();
+
+        //  AngleSharp hangs its non-DOM infrastructure - the parsers, the browsing context, the
+        //  requesters - off the very same EventTarget class the DOM is built on, so that name
+        //  alone says nothing about being part of the DOM. Everything the DOM does expose
+        //  carries a more specific name of its own.
+        private const String EventTargetName = "EventTarget";
+
+        /// <summary>
+        /// Gets whether instances of the type are represented by a DOM prototype rather than by
+        /// Jint's ordinary CLR wrapper.
+        /// </summary>
+        /// <remarks>
+        /// The name may well be inherited - a "b" element answers true through HTMLElement -
+        /// which is exactly what makes the DOM view the right one for it. Unlike
+        /// <see cref="GetDomPrototypeType"/> the answer depends on the type alone and not on the
+        /// engine's set of libraries, so the cache is process-wide.
+        /// </remarks>
+        public static Boolean IsDomType(this Type type) =>
+            _domTypes.GetOrAdd(type, static current =>
+            {
+                var name = GetCanonicalName(current);
+                return name != null && !String.Equals(name, EventTargetName, StringComparison.Ordinal);
+            });
 
         /// <summary>
         /// Gets what the constructor object of the type a prototype belongs to is built from,

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -8,6 +8,7 @@ namespace AngleSharp.Js
     using Jint.Native;
     using Jint.Native.Json;
     using Jint.Native.Object;
+    using Jint.Runtime.Interop;
     using System;
     using System.Collections.Generic;
     using System.Reflection;
@@ -37,6 +38,11 @@ namespace AngleSharp.Js
             _engine = new Engine((o) =>
             {
                 o.EnableModules(new JsModuleLoader(this, window.Document, false));
+                //  The handler answers out of the caches assigned right below, which only exist
+                //  once this constructor returns. Jint wraps nothing while it is configuring
+                //  itself, so that is safe - and Engine.Options is internal, so registering the
+                //  handler afterwards is not an option.
+                o.SetWrapObjectHandler(WrapObject);
                 //  Left alone, the JS call stack is the native one, and a script recursing
                 //  deeper than it holds takes the whole process down - a StackOverflowException
                 //  cannot be caught. Guarded, the engine continues on a fresh stack and finally
@@ -212,6 +218,19 @@ namespace AngleSharp.Js
         private DomNodeInstance CreateInstance(Object obj) => new DomNodeInstance(this, obj);
 
         private ObjectInstance CreatePrototype(Type type) => new DomPrototypeInstance(this, type);
+
+        /// <summary>
+        /// Converts a value handed over from C#, which reaches Jint through JsValue.FromObject
+        /// rather than through <see cref="EngineExtensions.ToJsValue"/>.
+        /// </summary>
+        /// <remarks>
+        /// A DOM object has to arrive as the DOM proxy for the very same reason it does when the
+        /// DOM itself yields one: the proxy is what carries the DOM members, and it is what makes
+        /// the object script already holds and the one passed in from C# the same object. Anything
+        /// else stays with Jint's CLR wrapper, which is what a host object is expected to be.
+        /// </remarks>
+        private ObjectInstance WrapObject(Engine engine, Object target, Type type) =>
+            target.GetType().IsDomType() ? GetDomNode(target) : ObjectWrapper.Create(engine, target, type);
 
         #endregion
     }


### PR DESCRIPTION
Fixes #76

## Cause

`JsValue.FromObject` is the conversion a C# caller reaches, and it is the one path that does not go through `EngineExtensions.ToJsValue`. Jint therefore wrapped an AngleSharp DOM object in its ordinary CLR `ObjectWrapper` rather than in the DOM proxy, and that wrapper is opaque to this library's own marshalling: `JsValueExtensions.FromJsValue` only unwraps a `DomNodeInstance`, so the argument came back out as the wrapper itself, `AsComplex` found no conversion from `ObjectWrapper` to `INode`, and the call died with `JavaScriptException: [Internal] Could not find corresponding cast target.` — the exception reported in the issue. Short of that, script also saw the CLR member surface (`TextContent`, `AppendChild`) instead of the DOM one, and the object was not the one `document.querySelector` hands back for the same node.

## Fix

`EngineInstance` installs a Jint `WrapObjectHandler`, the hook Jint consults whenever it wraps a CLR object. An object that resolves to a DOM name is converted with `GetDomNode`, so it goes through the same `ReferenceCache` the rest of the engine uses and one node keeps one JS object no matter which side hands it over. Everything else keeps Jint's `ObjectWrapper`, which is what a host object registered through `JsScriptingService.External` is expected to be.

`PrototypeTypeCache.IsDomType` is what decides, caching the answer per type since it depends on the type alone. The name may be inherited — a `b` element answers true through `HTMLElement`, which is exactly what makes the DOM view the right one for it — but a bare `EventTarget` is not enough: AngleSharp hangs `HtmlParser`, `BrowsingContext` and the requesters off the very same base class, and those are host objects that have to keep their CLR members.

## Behaviour change

An AngleSharp DOM object registered in `JsScriptingService.External` now reaches script as the DOM object rather than as a CLR wrapper, so script uses `doc.querySelector(…)` where it previously used `doc.QuerySelector(…)`. A collection handed over from C# likewise becomes the DOM collection, which means the array-like conveniences Jint's wrapper gave it (`Symbol.iterator`, the `Array.from` fast path) no longer apply — the same gap collections obtained from script already have. Host objects that are not part of the DOM are untouched.

## Tests

`InteractionTests` covers the issue's repro, the DOM member surface on a C#-created element, the JS identity of one node across the C# and the script path, and that a non-DOM AngleSharp host object keeps its CLR members.
