### PR TITLE
Fix vulnerable build dependencies

### DIFF
--- a/nuke/_build.csproj
+++ b/nuke/_build.csproj
@@ -12,10 +12,12 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="10.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.12.5" PrivateAssets="All" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="NuGet.CommandLine" Version="[6.12.2]" />
+    <PackageDownload Include="NuGet.CommandLine" Version="[6.12.5]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates NuGet.CommandLine to 6.12.5 and pins the vulnerable NuGet.Packaging and System.Security.Cryptography.Xml transitive dependencies to their patched releases. The restored build project reports no vulnerable packages.