### PR TITLE
Keep array-index keys out of the named getter, and declare the Jint the package needs

### DIFF
--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -232,6 +232,27 @@ namespace AngleSharp.Js.Tests
             Assert.AreEqual("1,title,t", result);
         }
 
+        //  An element whose id happens to be numeric must not surface as an index of the
+        //  collection. The array-like projection owns every array-index key - an index past the
+        //  end is authoritatively absent - so the named entry answers only non-index names,
+        //  which is also how WebIDL resolves the collision. Every answer has to say the same
+        //  thing, the descriptor included.
+        [Test]
+        public async Task NamedEntryWithAnIndexShapedNameIsNotAnIndex()
+        {
+            var result = await "(function () { var f = document.createElement('form'); f.id = '5'; document.documentElement.appendChild(f); var c = document.forms; return (Object.getOwnPropertyDescriptor(c, '5') === undefined) + ',' + ('5' in c) + ',' + (c['5'] === undefined) + ',' + c.hasOwnProperty('5') + ',' + (c[0] === f); })()".EvalScriptAsync();
+            Assert.AreEqual("true,false,true,false,true", result);
+        }
+
+        //  The guard above must not overreach: a named entry whose name is not an array index
+        //  keeps resolving, descriptor and all.
+        [Test]
+        public async Task NamedEntryWithAnOrdinaryNameStillResolves()
+        {
+            var result = await "(function () { var f = document.createElement('form'); f.id = 'login'; document.documentElement.appendChild(f); var c = document.forms; return (c.login === f) + ',' + (Object.getOwnPropertyDescriptor(c, 'login') !== undefined); })()".EvalScriptAsync();
+            Assert.AreEqual("true,true", result);
+        }
+
         //  A symbol cannot be an index, and it must not be turned into one either - the
         //  well-known symbols are probed on every kind of object by library code.
         [Test]

--- a/src/AngleSharp.Js.nuspec
+++ b/src/AngleSharp.Js.nuspec
@@ -18,27 +18,27 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
       <group targetFramework="net462">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
       <group targetFramework="net472">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
       <group targetFramework="net60">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
       <group targetFramework="net70">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
       <group targetFramework="net80">
         <dependency id="AngleSharp" version="[1.5.0,2.0.0)" />
-        <dependency id="Jint" version="[4.0.0,5.0.0)" />
+        <dependency id="Jint" version="[4.15.0,5.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
@@ -1,6 +1,7 @@
 namespace AngleSharp.Js
 {
     using AngleSharp.Js.Cache;
+    using Jint;
     using Jint.Native;
     using Jint.Native.Object;
     using Jint.Native.Symbol;
@@ -109,6 +110,16 @@ namespace AngleSharp.Js
                 return descriptor;
             }
 
+            //  The base has answered every array-index key authoritatively - an index past the
+            //  end is a miss its value and existence hooks already committed to - so the string
+            //  indexer must not be asked about one. WebIDL says the same: an object supporting
+            //  indexed properties never serves an array-index name from its named getter. An
+            //  element whose id is "5" is findable through a non-index name, never through 5.
+            if (IsArrayIndexName(property))
+            {
+                return PropertyDescriptor.Undefined;
+            }
+
             if (Prototype is DomPrototypeInstance prototype &&
                 prototype.TryGetFromNamedIndex(_value, property, out _))
             {
@@ -116,6 +127,33 @@ namespace AngleSharp.Js
             }
 
             return PropertyDescriptor.Undefined;
+        }
+
+        //  The test the engine's array-like model applies to a key, mirrored exactly so this
+        //  class and its base always classify a name the same way: a number holding a UInt32
+        //  below the maximum, or its canonical string form - no sign, no space, no leading zero.
+        private static Boolean IsArrayIndexName(JsValue property)
+        {
+            if (property.IsNumber())
+            {
+                var value = property.AsNumber();
+                var index = (UInt32)value;
+                return value == index && index != UInt32.MaxValue;
+            }
+
+            if (property.IsString())
+            {
+                var name = property.ToString();
+
+                if (name.Length == 0 || (name.Length > 1 && (name[0] < '1' || name[0] > '9')))
+                {
+                    return false;
+                }
+
+                return UInt32.TryParse(name, out var index) && index != UInt32.MaxValue;
+            }
+
+            return false;
         }
 
         protected override void SetOwnProperty(JsValue property, PropertyDescriptor desc)


### PR DESCRIPTION
Two follow-ups from a post-merge review of #130, one behavioural, one packaging. Both are small; the behavioural one comes with the regression tests that prove it both ways.

### 1. An array-index key must never reach the named getter

`DomCollectionInstance.GetOwnProperty` fell through to the string indexer for any key the array-like base did not answer — including an *array-index* key past the end. But the base's answer for such a key is not "I don't know", it is an authoritative *no*: the value and existence hooks (`TryGetOwnPropertyValue`, `ProbeOwnProperty`) commit to the miss, and Jint 4.15 trusts them without re-asking. So an element whose id happens to be numeric produced this, with one form `<form id='5'>` on the page:

```js
Object.getOwnPropertyDescriptor(document.forms, '5')   // a descriptor…
'5' in document.forms                                   // …for a key that answers false,
document.forms['5']                                     // reads as undefined,
document.forms.hasOwnProperty('5')                      // and is not an own property
```

Every answer except the descriptor was already correct — and browser-correct: WebIDL's `[[GetOwnProperty]]` for a platform object that supports indexed properties sets *ignoreNamedProps* when the index is unsupported, so a named element is never served under an array-index name. The fix makes the named lookup step aside for canonical array-index keys, classified exactly the way the engine classifies them (canonical form of a `UInt32` below the maximum), which restores the agreement the 4.15 hook contracts require — a Debug build of Jint asserts that agreement on every read, and this was the one reachable key class where it would have fired.

Reachable through any collection that has both indexers: `document.forms` / `form.elements` / other `HTMLCollection`s with an element whose `id`/`name` is numeric, and `el.attributes` with an attribute literally named like a number (HTML parsing permits those).

Two tests pin it: the numeric-id case now answers the same thing five ways, and a non-index named entry (`document.forms.login`) keeps resolving, descriptor included. Without the one-line guard the first test fails exactly on the descriptor field (`"false,false,true,false,true"`); with it, both pass.

### 2. The package manifest still promised Jint 4.0

`AngleSharp.Js.nuspec` declared `Jint [4.0.0,5.0.0)` in every group, but since #130 the assembly derives from `ArrayLikeObject` and overrides hooks that exist only in Jint **4.15.0** — and NuGet resolves the *lowest* version a range admits, so a consumer adding the package with defaults restored Jint 4.0.0 and got a `TypeLoadException` the moment a DOM object was projected. The nuspec is what `CreatePackage` packs, so the manifest is the shipped contract; the floor now names the version the code is written against. Worth cherry-picking into whatever ships after `1.0.0-beta.118`.

### Verification

`dotnet test` on `net8.0`, `net462`, `net472`, in **both Release and Debug**, against the released Jint 4.15.0 package: 230/230, 228/228, 228/228, all green, warning-clean. The A/B above (guard reverted, new tests only) was run to confirm the regression test bites before trusting it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uV6H9cTntzsoKiaJRBn4f
