### PR TITLE
Replace the ES5-era claims in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,17 @@ var numEntries = document.ExecuteScript("document.querySelectorAll('div').length
 
 ## Vision and Status
 
-The repository contains DOM bindings for the *Jint* JavaScript engine. *Jint* is fully ECMAScript 5 compatible and provides the basis for evaluating JavaScripts in the context of the AngleSharp DOM representation.
+The repository contains DOM bindings for the *Jint* JavaScript engine. *Jint* implements ECMAScript 2015 (ES6) through ECMAScript 2025 — classes and private fields, modules, generators, `async`/`await`, `Promise`, `Proxy`/`Reflect`, `Symbol`, typed arrays, `BigInt`, optional chaining, and iterator helpers among them — and provides the basis for evaluating JavaScripts in the context of the AngleSharp DOM representation. See the [Jint feature list](https://github.com/sebastienros/jint#supported-features) for the authoritative matrix.
 
-The library comes with a service that exposes `WithJs` to `IConfiguration`. This enables automatic evaluation of `script` elements that have a valid JavaScript type (or without any explicit type, since JavaScript is the default one). The DOM bindings are generated on the fly via reflection. Since *Jint* is interpreting JavaScript, the library can be published in compatibility with .NET Standard (2.0). The downside is that the performance is definitely worse than any compiled JavaScript engine would deliver. For most scripts that should not be a big issue.
+The library comes with a service that exposes `WithJs` to `IConfiguration`. This enables automatic evaluation of `script` elements that have a valid JavaScript type (or without any explicit type, since JavaScript is the default one), including `type="module"` and `type="importmap"`. The DOM bindings are generated on the fly via reflection. Since *Jint* is interpreting JavaScript, the library can be published in compatibility with .NET Standard (2.0). The downside is that the performance is definitely worse than any compiled JavaScript engine would deliver. For most scripts that should not be a big issue.
 
 ## Features
 
-- Support of ES5 through Jint
+- Support of modern JavaScript (ES2015 through ES2025) through Jint
 - Connection to the DOM
-- Evaluation of simple scripts (incl. jQuery)
+- ES modules and import maps (`<script type="module">`, `<script type="importmap">`)
+- Web Workers
+- Evaluation of real-world libraries (the test suite runs jQuery 1 through 4, React 16 and Bootstrap 5)
 
 ## Participating
 


### PR DESCRIPTION
The README still says *Jint* "is fully ECMAScript 5 compatible" and lists "Support of ES5 through Jint" as the headline feature. Jint has implemented ES2015 through ES2025 for several releases (we are on 4.15.3), so the README understates what scripts this binding can actually run — a reader evaluating AngleSharp.Js for a page built with classes, modules or `async`/`await` would conclude it cannot handle them.

## What changed

- *Vision and Status* now states the ES2015–ES2025 range with a handful of concrete features, and links to Jint's own feature matrix rather than restating a version number here that will go stale again.
- The same paragraph mentions that `type="module"` and `type="importmap"` scripts are evaluated, which `JsScriptingService.SupportsType` has accepted for a while but the README never said.
- *Features* replaces the ES5 bullet, adds ES modules / import maps and Web Workers (both shipping in 1.0.0 per the changelog), and replaces "Evaluation of simple scripts (incl. jQuery)" with the libraries the suite actually runs.

## Verification

I did not want to copy Jint's feature list on faith, so I ran the claims through this binding layer as script — private class fields, `async`/`await`, generators, optional chaining with `??`, spread of a `Set`, template literals, `Proxy`/`Reflect`/`BigInt`/`Symbol`, `Object.groupBy` (ES2024) and `Set.prototype.union` (ES2025) all evaluate correctly through `EvalScriptAsync`, as does destructuring a spread `querySelectorAll` result. Those probes were scratch tests and are not part of the diff.

Documentation only — no `CHANGELOG.md` entry, since nothing in the package changed. `docs/` carries no comparable stale claim; the only ES5 references in the repository were the two in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)