### PR TITLE
Move the build orchestrator to the Fallout stable channel (10.4.0)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
-      "version": "11.0.18",
+    "fallout.globaltool": {
+      "version": "10.4.0",
       "commands": [
         "fallout"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,5 @@ pip-log.txt
 
 # Fallout build tool
 .fallout/temp
+# The Python-era "build" pattern above would swallow the build project directory
+!/build/

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,9 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fallout.Common" Version="11.0.18" />
-    <!-- Transitive pin: Fallout.Common 11.0.18 still resolves 10.0.6, which carries advisories. -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="All" />
+    <PackageReference Include="Fallout.Common" Version="10.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fallout published [v10.4.0](https://github.com/Fallout-build/Fallout/releases/tag/v10.4.0), its first stable-channel release under the new dual-pace model. The 11.0.x line this repo pinned is the edge channel; 10.4.0 is newer (2026-08-07) and a feature superset despite the lower number (future stable releases move to CalVer, so the version line jumps ahead again).

Changes:

- `Fallout.Common` 11.0.18 → **10.4.0** in `build/_build.csproj`
- **Dropped the `System.Security.Cryptography.Xml` 10.0.10 transitive pin** — 10.4.0 resolves the patched version itself (Fallout-build/Fallout#618). Restore verified clean of NU19xx.
- Tool manifest switched from `fallout.cli` (edge-channel id, has no 10.4.0) to **`Fallout.GlobalTool` 10.4.0** — the stable-channel tool id per Fallout-build/Fallout#575. The `fallout` command name is unchanged, so `build.ps1`/`build.sh`/CI need no changes.
- `.gitignore`: un-ignore `/build/` — the Python-era `build` pattern silently hid any *new* file under the build project directory (existing tracked files were unaffected). Verified with a probe file.

Verification: `dotnet build build/_build.csproj` (0 warnings), `./build.ps1 Compile` end to end (tool restore resolves GlobalTool 10.4.0, Restore + Compile succeed). Publish targets intentionally not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)