### PR TITLE
Release 1.1.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
-      "version": "11.0.18",
+    "fallout.globaltool": {
+      "version": "10.4.0",
       "commands": [
         "fallout"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           10.0.x
 
     - name: Build
-      run: ./build.sh -AngleSharpVersion 1.5.0
+      run: ./build.sh -AngleSharpVersion 1.8.0
 
   windows:
     runs-on: windows-latest
@@ -72,9 +72,9 @@ jobs:
     - name: Build
       run: |
         if ($env:GITHUB_REF -eq "refs/heads/main") {
-          .\build.ps1 -Target Publish -AngleSharpVersion 1.5.0
+          .\build.ps1 -Target Publish -AngleSharpVersion 1.8.0
         } elseif ($env:GITHUB_REF -eq "refs/heads/devel") {
-          .\build.ps1 -Target PrePublish -AngleSharpVersion 1.5.0
+          .\build.ps1 -Target PrePublish -AngleSharpVersion 1.8.0
         } else {
-          .\build.ps1 -AngleSharpVersion 1.5.0
+          .\build.ps1 -AngleSharpVersion 1.8.0
         }

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,5 @@ pip-log.txt
 
 # Fallout build tool
 .fallout/temp
+# The Python-era "build" pattern above would swallow the build project directory
+!/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Released on Saturday, September 5 2026.
 
 - Updated to require at least AngleSharp 1.8.0
 - Added support for the `DomReturnType` attribute
+- Added support for the `DomSameObject` attribute
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Released on Saturday, September 5 2026.
 - Updated to require at least AngleSharp 1.8.0
 - Added support for the `DomReturnType` attribute
 - Added support for the `DomSameObject` attribute
+- Added iterable integration for `IEnumerable<T>` instances
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
+# 1.1.0
+
+Released on Saturday, September 5 2026.
+
+- Updated to require at least AngleSharp 1.8.0
+- Added support for the `DomReturnType` attribute
+
 # 1.0.1
 
 Released on Wednesday, August 5 2026.
 
+- Updated to require at least AngleSharp 1.5.0
 - Fixed `AmbiguousMatchException` in case of multiple `DomName` attributes (#136)
 - Added support for aliases with multiple `DomName` attributes
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,9 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fallout.Common" Version="11.0.18" />
-    <!-- Transitive pin: Fallout.Common 11.0.18 still resolves 10.0.6, which carries advisories. -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="All" />
+    <PackageReference Include="Fallout.Common" Version="10.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AngleSharp.Js.Docs/package.json
+++ b/src/AngleSharp.Js.Docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anglesharp/js",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "preview": true,
   "description": "The doclet for the AngleSharp.Js documentation.",
   "keywords": [

--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -88,6 +88,27 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task SameObjectPropertyReturnsTheSameObjectOnEveryAccess()
+        {
+            var result = await "document.images === document.images".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+
+        [Test]
+        public async Task SameObjectCollectionKeepsItsPropertiesAndUpdatesItsContents()
+        {
+            var result = await "(function () { var d = new DOMParser().parseFromString(`<body></body>`, 'text/html'); var images = d.images; images.marker = 'kept'; var img = d.createElement('img'); d.body.appendChild(img); return (images === d.images) + ',' + images.marker + ',' + images.length + ',' + (images[0] === img); })()".EvalScriptAsync();
+            Assert.AreEqual("true,kept,1,true", result);
+        }
+
+        [Test]
+        public async Task SameObjectTokenListKeepsItsPropertiesAndUpdatesItsContents()
+        {
+            var result = await "(function () { var d = document.createElement('div'); var list = d.classList; list.marker = 'kept'; d.className = 'a b'; return (list === d.classList) + ',' + list.marker + ',' + list.length + ',' + list[1]; })()".EvalScriptAsync();
+            Assert.AreEqual("true,kept,2,b", result);
+        }
+
+        [Test]
         public async Task ConsoleIsTheSameObjectOnEveryAccess()
         {
             var result = await "window.console === window.console".EvalScriptAsync();

--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -201,6 +201,20 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task QuerySelectorAllResultCanUseNodeListForEach()
+        {
+            var result = await "(function () { var nodes = document.querySelectorAll('script'); var names = []; nodes.forEach(function (node, index, collection) { names.push(index + ':' + node.nodeName + ':' + (collection === nodes)); }); return typeof nodes.forEach + ',' + names.join(); })()".EvalScriptAsync();
+            Assert.AreEqual("function,0:SCRIPT:true", result);
+        }
+
+        [Test]
+        public async Task QuerySelectorAllResultCanUseNodeListIterators()
+        {
+            var result = await "(function () { var nodes = document.querySelectorAll('script'); var entry = nodes.entries().next().value; return typeof nodes.entries + ',' + typeof nodes.keys + ',' + typeof nodes.values + ',' + nodes.keys().next().value + ',' + nodes.values().next().value.nodeName + ',' + entry[0] + ':' + entry[1].nodeName; })()".EvalScriptAsync();
+            Assert.AreEqual("function,function,function,0,SCRIPT,0:SCRIPT", result);
+        }
+
+        [Test]
         public async Task CollectionCanBeIterated()
         {
             var result = await "(function () { var n = 0; for (var s of document.getElementsByTagName('script')) { n += s.nodeName.length; } return n; })()".EvalScriptAsync();

--- a/src/AngleSharp.Js.Tests/DomTests.cs
+++ b/src/AngleSharp.Js.Tests/DomTests.cs
@@ -173,6 +173,13 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task QuerySelectorAllUsesItsDeclaredDomReturnType()
+        {
+            var result = await "(function () { var c = document.querySelectorAll('script'); return Object.prototype.toString.call(c) + ',' + (c instanceof NodeList) + ',' + (c instanceof HTMLCollection); })()".EvalScriptAsync();
+            Assert.AreEqual("[object NodeList],true,false", result);
+        }
+
+        [Test]
         public async Task CollectionCanBeIterated()
         {
             var result = await "(function () { var n = 0; for (var s of document.getElementsByTagName('script')) { n += s.nodeName.length; } return n; })()".EvalScriptAsync();

--- a/src/AngleSharp.Js/Cache/DomShapeCache.cs
+++ b/src/AngleSharp.Js/Cache/DomShapeCache.cs
@@ -258,6 +258,7 @@ namespace AngleSharp.Js.Cache
                 var indexParameters = property.GetIndexParameters();
                 var accessor = property.GetCustomAttribute<DomAccessorAttribute>()?.Type;
                 var putsForward = property.GetCustomAttribute<DomPutForwardsAttribute>();
+                var sameObject = property.GetCustomAttribute<DomSameObjectAttribute>() != null;
                 var names = property
                     .GetCustomAttributes<DomNameAttribute>()
                     .Select(m => m.OfficialName)
@@ -290,7 +291,7 @@ namespace AngleSharp.Js.Cache
 
                 foreach (var name in names)
                 {
-                    SetProperty(name, property.GetMethod, property.SetMethod, putsForward);
+                    SetProperty(name, property.GetMethod, property.SetMethod, putsForward, sameObject);
                 }
             }
         }
@@ -309,8 +310,8 @@ namespace AngleSharp.Js.Cache
         private void SetEvent(String name, MethodInfo adder, MethodInfo remover) =>
             Define(name, new EventMember(new DomEventDefinition(adder, remover)));
 
-        private void SetProperty(String name, MethodInfo getter, MethodInfo setter, DomPutForwardsAttribute putsForward) =>
-            Define(name, new PropertyMember(getter, setter, putsForward));
+        private void SetProperty(String name, MethodInfo getter, MethodInfo setter, DomPutForwardsAttribute putsForward, Boolean sameObject = false) =>
+            Define(name, new PropertyMember(getter, setter, putsForward, sameObject));
 
         private void SetIndexer(PropertyInfo property, ParameterInfo[] indexParameters)
         {
@@ -428,12 +429,14 @@ namespace AngleSharp.Js.Cache
             private readonly MethodInfo _getter;
             private readonly MethodInfo _setter;
             private readonly DomPutForwardsAttribute _putsForward;
+            private readonly Boolean _sameObject;
 
-            public PropertyMember(MethodInfo getter, MethodInfo setter, DomPutForwardsAttribute putsForward)
+            public PropertyMember(MethodInfo getter, MethodInfo setter, DomPutForwardsAttribute putsForward, Boolean sameObject)
             {
                 _getter = getter;
                 _setter = setter;
                 _putsForward = putsForward;
+                _sameObject = sameObject;
             }
 
             //  Both halves are declared even when only one accessor exists, because that is what
@@ -446,6 +449,9 @@ namespace AngleSharp.Js.Cache
                 var getter = _getter;
                 var setter = _setter;
                 var putsForward = _putsForward;
+                var read = _sameObject
+                    ? (Func<JsValue, JsValue[], JsValue>)((thisObject, arguments) => EngineExtensions.CallSameObject(getter, thisObject))
+                    : ((thisObject, arguments) => EngineExtensions.CallShared(getter, thisObject, arguments));
 
                 //  The forwarding case is decided here rather than per write: it is rare, and the
                 //  ordinary setter is on the hot path for every attribute a script assigns.
@@ -455,7 +461,7 @@ namespace AngleSharp.Js.Cache
 
                 builder.Accessor(
                     name,
-                    (thisObject, arguments) => EngineExtensions.CallShared(getter, thisObject, arguments),
+                    read,
                     write,
                     enumerable: false,
                     configurable: false);

--- a/src/AngleSharp.Js/Cache/MethodCache.cs
+++ b/src/AngleSharp.Js/Cache/MethodCache.cs
@@ -28,6 +28,7 @@ namespace AngleSharp.Js.Cache
 
             Parameters = descriptions;
             InitDict = method.GetCustomAttribute<DomInitDictAttribute>();
+            ReturnType = method.GetCustomAttribute<DomReturnTypeAttribute>()?.ReturnType;
             TakesWindow = parameters.Length > 0 && parameters[0].ParameterType == typeof(IWindow);
             TakesParamArray = parameters.Length > 0 &&
                 parameters[parameters.Length - 1].GetCustomAttribute<ParamArrayAttribute>() != null;
@@ -39,6 +40,8 @@ namespace AngleSharp.Js.Cache
         public ParameterDescription[] Parameters { get; }
 
         public DomInitDictAttribute InitDict { get; }
+
+        public Type ReturnType { get; }
 
         public Boolean TakesWindow { get; }
 

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -8,10 +8,12 @@ namespace AngleSharp.Js
     using Jint.Native;
     using Jint.Native.Json;
     using Jint.Native.Object;
+    using Jint.Runtime;
     using Jint.Runtime.Interop;
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
 
     sealed class EngineInstance
     {
@@ -23,6 +25,7 @@ namespace AngleSharp.Js
         private readonly Engine _engine;
         private readonly PrototypeCache _prototypes;
         private readonly ReferenceCache _references;
+        private readonly ConditionalWeakTable<Object, SameObjectCache> _sameObjects;
         private readonly LibrarySet _libs;
         private readonly DomNodeInstance _window;
         private readonly JsImportMap _importMap;
@@ -52,6 +55,7 @@ namespace AngleSharp.Js
             _libs = new LibrarySet(libs);
             _prototypes = new PrototypeCache(_engine, _libs);
             _references = new ReferenceCache();
+            _sameObjects = new ConditionalWeakTable<Object, SameObjectCache>();
 
             foreach (var assignment in assignments)
             {
@@ -101,6 +105,31 @@ namespace AngleSharp.Js
         public ObjectInstance GetDomNode(Object obj, Type type) => CreateInstance(obj, type);
 
         public ObjectInstance GetDomPrototype(Type type) => _prototypes.GetOrCreate(type, CreatePrototype);
+
+        public JsValue GetSameObject(Object owner, MethodInfo getter)
+        {
+            if (getter == null)
+            {
+                return JsValue.Undefined;
+            }
+
+            try
+            {
+                var current = getter.Invoke(owner, Array.Empty<Object>());
+
+                if (current == null)
+                {
+                    return JsValue.Null;
+                }
+
+                var cache = _sameObjects.GetValue(owner, _ => new SameObjectCache());
+                return cache.GetOrUpdate(getter, current, () => CreateInstance(current, getter.ReturnType));
+            }
+            catch (TargetInvocationException)
+            {
+                throw new JavaScriptException(_engine.Intrinsics.Error);
+            }
+        }
 
         /// <summary>
         /// Gets the constructor object of the given type, building it on first ask. The
@@ -268,6 +297,29 @@ namespace AngleSharp.Js
         /// </remarks>
         private ObjectInstance WrapObject(Engine engine, Object target, Type type) =>
             target.GetType().IsDomType() ? GetDomNode(target) : ObjectWrapper.Create(engine, target, type);
+
+        private sealed class SameObjectCache
+        {
+            private readonly Dictionary<MethodInfo, ObjectInstance> _entries = new Dictionary<MethodInfo, ObjectInstance>();
+
+            public ObjectInstance GetOrUpdate(MethodInfo getter, Object value, Func<ObjectInstance> create)
+            {
+                lock (_entries)
+                {
+                    if (!_entries.TryGetValue(getter, out var instance))
+                    {
+                        instance = create.Invoke();
+                        _entries.Add(getter, instance);
+                    }
+                    else if (instance is IDomProxy proxy)
+                    {
+                        proxy.Update(value);
+                    }
+
+                    return instance;
+                }
+            }
+        }
 
         #endregion
     }

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -98,6 +98,8 @@ namespace AngleSharp.Js
 
         public ObjectInstance GetDomNode(Object obj) => _references.GetOrCreate(obj, CreateInstance);
 
+        public ObjectInstance GetDomNode(Object obj, Type type) => CreateInstance(obj, type);
+
         public ObjectInstance GetDomPrototype(Type type) => _prototypes.GetOrCreate(type, CreatePrototype);
 
         /// <summary>
@@ -218,16 +220,18 @@ namespace AngleSharp.Js
         //  A collection is projected by the array-like proxy, which lets the engine read its
         //  indices and length directly; everything else by the ordinary one. The decision is a
         //  property of the type, so it is resolved once per type for the whole process.
-        private ObjectInstance CreateInstance(Object obj)
+        private ObjectInstance CreateInstance(Object obj) => CreateInstance(obj, obj.GetType());
+
+        private ObjectInstance CreateInstance(Object obj, Type type)
         {
-            var collection = obj.GetType().GetIndexedCollection();
+            var collection = type.GetIndexedCollection();
 
             if (collection != null)
             {
-                return new DomCollectionInstance(this, obj, collection);
+                return new DomCollectionInstance(this, obj, type, collection);
             }
 
-            return new DomNodeInstance(this, obj);
+            return new DomNodeInstance(this, obj, type);
         }
 
         /// <summary>
@@ -254,7 +258,7 @@ namespace AngleSharp.Js
 
         /// <summary>
         /// Converts a value handed over from C#, which reaches Jint through JsValue.FromObject
-        /// rather than through <see cref="EngineExtensions.ToJsValue"/>.
+        /// rather than through <see cref="EngineExtensions.ToJsValue(Object, EngineInstance)"/>.
         /// </summary>
         /// <remarks>
         /// A DOM object has to arrive as the DOM proxy for the very same reason it does when the

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -65,6 +65,16 @@ namespace AngleSharp.Js
             return JsValue.Null;
         }
 
+        public static JsValue ToJsValue(this Object obj, EngineInstance engine, Type type)
+        {
+            if (obj != null && type != null && type.IsDomType())
+            {
+                return engine.GetDomNode(obj, type);
+            }
+
+            return obj.ToJsValue(engine);
+        }
+
         public static ClrFunction AsValue(this Engine engine, string name, Func<JsValue, JsValue[], JsValue> func) =>
             new ClrFunction(engine, name, func);
 
@@ -427,18 +437,20 @@ namespace AngleSharp.Js
 
                 try
                 {
+                    var description = MethodDescription.Of(method);
+
                     if (method.IsStatic)
                     {
                         var newArgs = new JsValue[arguments.Length + 1];
                         newArgs[0] = (JsValue)nodeInstance;
                         Array.Copy(arguments, 0, newArgs, 1, arguments.Length);
                         var parameters = instance.BuildArgs(method, newArgs);
-                        return method.Invoke(null, parameters).ToJsValue(instance);
+                        return method.Invoke(null, parameters).ToJsValue(instance, description.ReturnType);
                     }
                     else
                     {
                         var parameters = instance.BuildArgs(method, arguments);
-                        return method.Invoke(nodeInstance.Value, parameters).ToJsValue(instance);
+                        return method.Invoke(nodeInstance.Value, parameters).ToJsValue(instance, description.ReturnType);
                     }
                 }
                 catch (TargetInvocationException)

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -420,6 +420,19 @@ namespace AngleSharp.Js
             return instance.Call(method, thisObject, arguments);
         }
 
+        public static JsValue CallSameObject(MethodInfo method, JsValue thisObject)
+        {
+            var instance = thisObject.GetEngineInstance();
+
+            if (instance == null)
+            {
+                throw new JavaScriptException("Illegal invocation.");
+            }
+
+            var target = thisObject is IDomProxy node ? node.Value : instance.Window.Value;
+            return instance.GetSameObject(target, method);
+        }
+
         public static JsValue Call(this EngineInstance instance, MethodInfo method, JsValue thisObject, JsValue[] arguments)
         {
             if (method != null)

--- a/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
@@ -23,9 +23,9 @@ namespace AngleSharp.Js
     sealed class DomCollectionInstance : ArrayLikeObject, IDomProxy
     {
         private readonly EngineInstance _instance;
-        private readonly Object _value;
         private readonly Type _type;
         private readonly IndexedCollection _collection;
+        private Object _value;
 
         private DomPrototypeState _state;
 
@@ -54,6 +54,8 @@ namespace AngleSharp.Js
         public Type DomType => _type;
 
         public EngineInstance Instance => _instance;
+
+        public void Update(Object value) => _value = value;
 
         //  Remembered rather than reached through two type tests per lookup, and checked against
         //  the prototype in force because a script may hand the collection another one.

--- a/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
@@ -7,6 +7,7 @@ namespace AngleSharp.Js
     using Jint.Native.Symbol;
     using Jint.Runtime.Descriptors;
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
 
     /// <summary>
@@ -47,6 +48,15 @@ namespace AngleSharp.Js
             FastSetProperty(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(
                 engine.Jint.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator),
                 true, false, true));
+
+            if (IsIterable(type))
+            {
+                var arrayPrototype = engine.Jint.Intrinsics.Array.PrototypeObject;
+                FastSetProperty("entries", new PropertyDescriptor(arrayPrototype.Get("entries"), true, false, true));
+                FastSetProperty("forEach", new PropertyDescriptor(arrayPrototype.Get("forEach"), true, false, true));
+                FastSetProperty("keys", new PropertyDescriptor(arrayPrototype.Get("keys"), true, false, true));
+                FastSetProperty("values", new PropertyDescriptor(arrayPrototype.Get("values"), true, false, true));
+            }
         }
 
         public Object Value => _value;
@@ -122,6 +132,24 @@ namespace AngleSharp.Js
         /// the whole test suite is the proof.
         /// </remarks>
         protected override Boolean HasIndex(UInt32 index) => index < Length;
+
+        private static Boolean IsIterable(Type type)
+        {
+            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return true;
+            }
+
+            foreach (var contract in type.GetTypeInfo().ImplementedInterfaces)
+            {
+                if (contract.GetTypeInfo().IsGenericType && contract.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Named entries - "document.forms.login", "el.attributes.title" - are the one thing a

--- a/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomCollectionInstance.cs
@@ -24,18 +24,20 @@ namespace AngleSharp.Js
     {
         private readonly EngineInstance _instance;
         private readonly Object _value;
+        private readonly Type _type;
         private readonly IndexedCollection _collection;
 
         private DomPrototypeState _state;
 
-        public DomCollectionInstance(EngineInstance engine, Object value, IndexedCollection collection)
+        public DomCollectionInstance(EngineInstance engine, Object value, Type type, IndexedCollection collection)
             : base(engine.Jint)
         {
             _instance = engine;
             _value = value;
+            _type = type;
             _collection = collection;
 
-            var prototype = engine.GetDomPrototype(value.GetType());
+            var prototype = engine.GetDomPrototype(type);
             Prototype = prototype;
             _state = DomPrototypeState.Of(prototype);
 
@@ -48,6 +50,8 @@ namespace AngleSharp.Js
         }
 
         public Object Value => _value;
+
+        public Type DomType => _type;
 
         public EngineInstance Instance => _instance;
 

--- a/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorInstance.cs
@@ -67,7 +67,7 @@ namespace AngleSharp.Js
         {
             var value = arguments.Length > 0 ? arguments[0] : JsValue.Undefined;
 
-            if (value is IDomProxy node && IsInstance(node.Value))
+            if (value is IDomProxy node && IsInstance(node.DomType))
             {
                 return JsBoolean.True;
             }
@@ -77,10 +77,8 @@ namespace AngleSharp.Js
             return InheritsFromPrototype(value as ObjectInstance) ? JsBoolean.True : JsBoolean.False;
         }
 
-        private Boolean IsInstance(Object value)
+        private Boolean IsInstance(Type type)
         {
-            var type = value.GetType();
-
             if (_type.IsAssignableFrom(type))
             {
                 return true;

--- a/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
@@ -11,17 +11,19 @@ namespace AngleSharp.Js
     {
         private readonly EngineInstance _instance;
         private readonly Object _value;
+        private readonly Type _type;
 
         private Dictionary<DomEventDefinition, DomEventDefinition.Registration> _eventHandlers;
         private DomPrototypeState _state;
 
-        public DomNodeInstance(EngineInstance engine, Object value)
+        public DomNodeInstance(EngineInstance engine, Object value, Type type)
             : base(engine.Jint)
         {
             _instance = engine;
             _value = value;
+            _type = type;
 
-            var prototype = engine.GetDomPrototype(value.GetType());
+            var prototype = engine.GetDomPrototype(type);
             Prototype = prototype;
             _state = DomPrototypeState.Of(prototype);
         }
@@ -54,6 +56,8 @@ namespace AngleSharp.Js
         }
 
         public Object Value => _value;
+
+        public Type DomType => _type;
 
         public EngineInstance Instance => _instance;
 

--- a/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomNodeInstance.cs
@@ -10,8 +10,8 @@ namespace AngleSharp.Js
     sealed class DomNodeInstance : ObjectInstance, IDomProxy
     {
         private readonly EngineInstance _instance;
-        private readonly Object _value;
         private readonly Type _type;
+        private Object _value;
 
         private Dictionary<DomEventDefinition, DomEventDefinition.Registration> _eventHandlers;
         private DomPrototypeState _state;
@@ -60,6 +60,8 @@ namespace AngleSharp.Js
         public Type DomType => _type;
 
         public EngineInstance Instance => _instance;
+
+        public void Update(Object value) => _value = value;
 
         public override object ToObject() => _value;
 

--- a/src/AngleSharp.Js/Proxies/IDomProxy.cs
+++ b/src/AngleSharp.Js/Proxies/IDomProxy.cs
@@ -19,6 +19,11 @@ namespace AngleSharp.Js
         Object Value { get; }
 
         /// <summary>
+        /// Gets the DOM type this proxy is projected as.
+        /// </summary>
+        Type DomType { get; }
+
+        /// <summary>
         /// Gets the engine the proxy belongs to. A prototype member is shared by every engine
         /// and reaches its own through whichever object it was invoked on.
         /// </summary>

--- a/src/AngleSharp.Js/Proxies/IDomProxy.cs
+++ b/src/AngleSharp.Js/Proxies/IDomProxy.cs
@@ -24,6 +24,11 @@ namespace AngleSharp.Js
         Type DomType { get; }
 
         /// <summary>
+        /// Refreshes the DOM object this proxy stands for.
+        /// </summary>
+        void Update(Object value);
+
+        /// <summary>
         /// Gets the engine the proxy belongs to. A prototype member is shared by every engine
         /// and reaches its own through whichever object it was invoked on.
         /// </summary>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
        entry of CHANGELOG.md, which build/Build.cs passes in as -p:Version, so this value only
        affects a plain `dotnet build` and no longer needs bumping for a release. -->
   <PropertyGroup Label="Versioning">
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Compilation">
@@ -26,6 +26,6 @@
        NuGet resolves the lowest match, so a build cannot quietly take a dependency on an API
        added in a later 1.x. -->
   <PropertyGroup Label="Dependencies">
-    <AngleSharpVersion Condition=" '$(AngleSharpVersion)' == '' ">1.5.0</AngleSharpVersion>
+    <AngleSharpVersion Condition=" '$(AngleSharpVersion)' == '' ">1.8.0</AngleSharpVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Makes AngleSharp 1.8.0 the baseline. Introduces support for DOM iterables, as well as the new attributes coming with AngleSharp 1.8.0. Adds support for same object and different return type annotations.
